### PR TITLE
System::supercell was changed to be private. Direction to use more getter and setter. 

### DIFF
--- a/src/alm.cpp
+++ b/src/alm.cpp
@@ -228,8 +228,7 @@ void ALM::set_cell(const int nat,
                      system->nat,
                      system->nkd,
                      system->kd,
-                     system->xcoord,
-                     system->supercell);
+                     system->xcoord);
 }
 
 void ALM::set_magnetic_params(const double *magmom,
@@ -328,7 +327,7 @@ void ALM::set_norder(const int maxorder) const // NORDER harmonic=1
         interaction->nbody_include[i] = i + 2;
     }
 
-    nkd = system->supercell.number_of_elems;
+    nkd = system->get_cell().number_of_elems;
     if (interaction->cutoff_radii) {
         deallocate(interaction->cutoff_radii);
     }
@@ -359,7 +358,7 @@ void ALM::set_nbody_include(const int *nbody_include) const // NBODY
 
 void ALM::set_cutoff_radii(const double *rcs) const
 {
-    const int nkd = system->supercell.number_of_elems;
+    const int nkd = system->get_cell().number_of_elems;
     const auto maxorder = interaction->maxorder;
 
     if (maxorder > 0) {
@@ -699,7 +698,7 @@ int ALM::optimize()
                                 constraint,
                                 fcs,
                                 interaction->maxorder,
-                                system->supercell.number_of_atoms,
+                                system->get_cell().number_of_atoms,
                                 verbosity,
                                 files->file_disp,
                                 files->file_force,
@@ -737,7 +736,7 @@ int ALM::optimize_lasso()
                       interaction,
                       fcs,
                       constraint,
-                      system->supercell.number_of_atoms,
+                      system->get_cell().number_of_atoms,
                       files,
                       verbosity,
                       fitting,
@@ -769,7 +768,7 @@ void ALM::initialize_interaction()
                       timer);
     fcs->init(interaction,
               symmetry,
-              system->supercell.number_of_atoms,
+              system->get_cell().number_of_atoms,
               verbosity,
               timer);
 

--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -223,7 +223,7 @@ void Constraint::setup(const System *system,
                                    const_fix[1]);
     }
 
-    generate_symmetry_constraint_in_cartesian(system->supercell.number_of_atoms,
+    generate_symmetry_constraint_in_cartesian(system->get_cell().number_of_atoms,
                                               symmetry,
                                               interaction,
                                               fcs,
@@ -242,7 +242,7 @@ void Constraint::setup(const System *system,
     }
 
     if (impose_inv_T) {
-        generate_translational_constraint(system->supercell,
+        generate_translational_constraint(system->get_cell(),
                                           symmetry,
                                           interaction,
                                           fcs,
@@ -1324,7 +1324,7 @@ void Constraint::generate_rotational_constraint(const System *system,
                                             if (!interaction->is_incutoff(order + 2,
                                                                           interaction_atom,
                                                                           order,
-                                                                          system->supercell.kind))
+                                                                          system->get_cell().kind))
                                                 continue;
 
                                             atom_tmp.clear();

--- a/src/interaction.cpp
+++ b/src/interaction.cpp
@@ -44,8 +44,8 @@ void Interaction::init(const System *system,
     timer->start_clock("interaction");
 
     int i, j, k;
-    int nat = system->supercell.number_of_atoms;
-    int nkd = system->supercell.number_of_elems;
+    int nat = system->get_cell().number_of_atoms;
+    int nkd = system->get_cell().number_of_elems;
 
     if (verbosity > 0) {
         std::cout << " INTERACTION" << std::endl;
@@ -83,15 +83,15 @@ void Interaction::init(const System *system,
                                   system->x_image,
                                   system->exist_image);
 
-    set_interaction_by_cutoff(system->supercell.number_of_atoms,
-                              system->supercell.kind,
+    set_interaction_by_cutoff(system->get_cell().number_of_atoms,
+                              system->get_cell().kind,
                               symmetry->nat_prim,
                               symmetry->map_p2s,
                               cutoff_radii,
                               interaction_pair);
 
     calc_interaction_clusters(symmetry->nat_prim,
-                              system->supercell.kind,
+                              system->get_cell().kind,
                               symmetry->map_p2s,
                               interaction_pair,
                               system->x_image,
@@ -122,17 +122,17 @@ void Interaction::init(const System *system,
             std::cout << std::endl;
         }
 
-        print_neighborlist(system->supercell.number_of_atoms,
+        print_neighborlist(system->get_cell().number_of_atoms,
                            symmetry->nat_prim,
                            symmetry->map_p2s,
-                           system->supercell.kind,
+                           system->get_cell().kind,
                            system->kdname);
     }
 
     if (verbosity > 1) {
         print_interaction_information(symmetry->nat_prim,
                                       symmetry->map_p2s,
-                                      system->supercell.kind,
+                                      system->get_cell().kind,
                                       system->kdname,
                                       interaction_pair);
     }

--- a/src/patterndisp.cpp
+++ b/src/patterndisp.cpp
@@ -95,13 +95,13 @@ void Displace::gen_displacement_pattern(const Interaction *interaction,
     for (order = 0; order < maxorder; ++order) {
 
         fcs->generate_force_constant_table(order,
-                                           system->supercell.number_of_atoms,
+                                           system->get_cell().number_of_atoms,
                                            interaction->cluster_list[order],
                                            symmetry, preferred_basis,
                                            fc_table[order], nequiv[order],
                                            fc_zeros[order], false);
 
-        fcs->get_constraint_symmetry(system->supercell.number_of_atoms,
+        fcs->get_constraint_symmetry(system->get_cell().number_of_atoms,
                                      symmetry,
                                      order,
                                      interaction->cluster_list[order],
@@ -192,8 +192,8 @@ void Displace::gen_displacement_pattern(const Interaction *interaction,
 
     allocate(pattern_all, maxorder);
     generate_pattern_all(maxorder,
-                         system->supercell.number_of_atoms,
-                         system->supercell.lattice_vector,
+                         system->get_cell().number_of_atoms,
+                         system->get_cell().lattice_vector,
                          symmetry,
                          pattern_all,
                          dispset, preferred_basis);

--- a/src/symmetry.cpp
+++ b/src/symmetry.cpp
@@ -50,7 +50,7 @@ void Symmetry::init(const System *system,
     }
 
 
-    setup_symmetry_operation(system->supercell,
+    setup_symmetry_operation(system->get_cell(),
                              system->is_periodic,
                              system->atomtype_group,
                              system->spin,
@@ -68,7 +68,7 @@ void Symmetry::init(const System *system,
     //                       kd_prim, xcoord_prim,
     //                       tolerance);
 
-    int nat = system->supercell.number_of_atoms;
+    int nat = system->get_cell().number_of_atoms;
 
     if (map_sym) {
         deallocate(map_sym);
@@ -80,7 +80,7 @@ void Symmetry::init(const System *system,
     }
     allocate(map_p2s, nat_prim, ntran);
 
-    gen_mapping_information(system->supercell,
+    gen_mapping_information(system->get_cell(),
                             system->atomtype_group,
                             SymmData,
                             symnum_tran,

--- a/src/system.h
+++ b/src/system.h
@@ -66,11 +66,12 @@ namespace ALM_NS
         void frac2cart(double **) const;
 
         void set_cell(const double [3][3],
-                      unsigned int,
-                      unsigned int,
-                      int *,
-                      double **,
-                      Cell &) const;
+                      const unsigned int,
+                      const unsigned int,
+                      const int *,
+                      const double * const *);
+
+        Cell get_cell() const;
 
         void set_spin_variable(bool,
                                int,
@@ -78,7 +79,6 @@ namespace ALM_NS
                                unsigned int,
                                double **);
 
-        Cell primitivecell, supercell;
         Spin spin;
 
         std::string *kdname;
@@ -104,6 +104,8 @@ namespace ALM_NS
         double **xcoord; // fractional coordinate
 
     private:
+        Cell supercell;
+
         enum LatticeType { Direct, Reciprocal };
 
         void set_reciprocal_latt(const double [3][3], double [3][3]) const;

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -232,12 +232,12 @@ void Writer::write_force_constants(ALM *alm) const
     ofs_fcs << std::endl;
 
     /*  if (alm->constraint->extra_constraint_from_symmetry) {
-  
+
           ofs_fcs << " -------------- Constraints from crystal symmetry --------------" << std::endl << std::endl;
           for (order = 0; order < maxorder; ++order) {
               int nparam = alm->fcs->nequiv[order].size();
-  
-  
+
+
               for (auto p = alm->constraint->const_symmetry[order].begin();
                    p != alm->constraint->const_symmetry[order].end();
                    ++p) {
@@ -375,22 +375,22 @@ void Writer::write_misc_xml(ALM *alm)
     for (i = 0; i < 3; ++i) {
         for (j = 0; j < 3; ++j) {
             system_structure.lattice_vector[i][j]
-                = alm->system->supercell.lattice_vector[i][j];
+                = alm->system->get_cell().lattice_vector[i][j];
         }
     }
 
-    system_structure.nat = alm->system->supercell.number_of_atoms;
+    system_structure.nat = alm->system->get_cell().number_of_atoms;
     system_structure.natmin = alm->symmetry->nat_prim;
     system_structure.ntran = alm->symmetry->ntran;
-    system_structure.nspecies = alm->system->supercell.number_of_elems;
+    system_structure.nspecies = alm->system->get_cell().number_of_elems;
 
     AtomProperty prop_tmp;
 
-    for (i = 0; i < alm->system->supercell.number_of_atoms; ++i) {
-        prop_tmp.x = alm->system->supercell.x_fractional[i][0];
-        prop_tmp.y = alm->system->supercell.x_fractional[i][1];
-        prop_tmp.z = alm->system->supercell.x_fractional[i][2];
-        prop_tmp.kind = alm->system->supercell.kind[i];
+    for (i = 0; i < alm->system->get_cell().number_of_atoms; ++i) {
+        prop_tmp.x = alm->system->get_cell().x_fractional[i][0];
+        prop_tmp.y = alm->system->get_cell().x_fractional[i][1];
+        prop_tmp.z = alm->system->get_cell().x_fractional[i][2];
+        prop_tmp.kind = alm->system->get_cell().kind[i];
         prop_tmp.atom = alm->symmetry->map_s2p[i].atom_num + 1;
         prop_tmp.tran = alm->symmetry->map_s2p[i].tran_num + 1;
 
@@ -438,10 +438,10 @@ void Writer::write_misc_xml(ALM *alm)
 
     for (i = 0; i < system_structure.nat; ++i) {
         str_tmp.clear();
-        for (j = 0; j < 3; ++j) str_tmp += " " + double2string(alm->system->supercell.x_fractional[i][j]);
+        for (j = 0; j < 3; ++j) str_tmp += " " + double2string(alm->system->get_cell().x_fractional[i][j]);
         ptree &child = pt.add("Data.Structure.Position.pos", str_tmp);
         child.put("<xmlattr>.index", i + 1);
-        child.put("<xmlattr>.element", alm->system->kdname[alm->system->supercell.kind[i] - 1]);
+        child.put("<xmlattr>.element", alm->system->kdname[alm->system->get_cell().kind[i] - 1]);
     }
 
     pt.put("Data.Symmetry.NumberOfTranslations", alm->symmetry->ntran);
@@ -690,7 +690,7 @@ void Writer::write_hessian(ALM *alm) const
     double **hessian;
 
     //ALMCore *alm = alm->get_alm();
-    int nat3 = 3 * alm->system->supercell.number_of_atoms;
+    int nat3 = 3 * alm->system->get_cell().number_of_atoms;
 
     allocate(hessian, nat3, nat3);
 
@@ -756,7 +756,7 @@ void Writer::write_in_QEformat(ALM *alm) const
     int pair_tran[2];
     std::ofstream ofs_hes;
     double **hessian;
-    int nat3 = 3 * alm->system->supercell.number_of_atoms;
+    int nat3 = 3 * alm->system->get_cell().number_of_atoms;
 
     allocate(hessian, nat3, nat3);
 
@@ -788,8 +788,8 @@ void Writer::write_in_QEformat(ALM *alm) const
     ofs_hes << "  1  1  1" << std::endl;
     for (int icrd = 0; icrd < 3; ++icrd) {
         for (int jcrd = 0; jcrd < 3; ++jcrd) {
-            for (i = 0; i < alm->system->supercell.number_of_atoms; ++i) {
-                for (j = 0; j < alm->system->supercell.number_of_atoms; ++j) {
+            for (i = 0; i < alm->system->get_cell().number_of_atoms; ++i) {
+                for (j = 0; j < alm->system->get_cell().number_of_atoms; ++j) {
                     ofs_hes << std::setw(3) << icrd + 1;
                     ofs_hes << std::setw(3) << jcrd + 1;
                     ofs_hes << std::setw(3) << i + 1;


### PR DESCRIPTION
This pull request is an example to show a direction to use more getter and setter. I think this is a matter of developer's taste, so you can decide if you will merge or not. In C++, except for trivial cases, I think it is better to use getter and setter though this is not the case for Python.
By this change, all `system->supercell` were replaced by `system->get_cell()`. `System::set_cell()` seemed to invoke only to define `supercell`, so I modified `set_cell()` not to have Cell instance as input, rather directory access to `System::supercell` in it. It seems `System::primiticell` is not used anywhere, so I removed.