### PR TITLE
Set public variables of System class to private

### DIFF
--- a/python/_alm.c
+++ b/python/_alm.c
@@ -541,14 +541,12 @@ static PyObject * py_set_fc(PyObject *self, PyObject *args)
 static PyObject * py_get_matrix_elements(PyObject *self, PyObject *args)
 {
   int id;
-  int nat;
   int ndata_used;
   PyArrayObject* py_amat;
   PyArrayObject* py_bvec;
 
-  if (!PyArg_ParseTuple(args, "iiiOO",
+  if (!PyArg_ParseTuple(args, "iiOO",
                               &id,
-                              &nat,
                               &ndata_used,
                               &py_amat,
                               &py_bvec)) {
@@ -558,7 +556,7 @@ static PyObject * py_get_matrix_elements(PyObject *self, PyObject *args)
   double (*amat) = (double(*))PyArray_DATA(py_amat);
   double (*bvec) = (double(*))PyArray_DATA(py_bvec);
 
-  alm_get_matrix_elements(id, nat, ndata_used, amat, bvec);
+  alm_get_matrix_elements(id, ndata_used, amat, bvec);
 
   Py_RETURN_NONE;
 }

--- a/python/alm/alm.py
+++ b/python/alm/alm.py
@@ -105,7 +105,7 @@ class ALM:
         ----------
         solver : str, default='dense'
             Solver choice for fitting either 'dense' or 'SimplicialLDLT'.
-            
+
             - When solver='dense', the fitting is performed with the
               singular value decomposition implemented in LAPACK.
             - When solver='SimplicialLDLT', the fitting is performed with
@@ -163,7 +163,7 @@ class ALM:
         ----------
         norder : int
             Maximum order of the Taylor expansion potential.
-            
+
             - If ``norder = 1``, only harmonic (2nd-order) terms are considered.
             - If ``norder = 2``, both harmonic and cubic terms are considered.
 
@@ -218,7 +218,7 @@ class ALM:
 
         if rotation is True:
             print("Rotational invariance is not supported in API.")
-            raise 
+            raise
 
         if translation is True:
             iconst = 11
@@ -234,7 +234,7 @@ class ALM:
         Parameters
         ----------
         verbosity : int
-            Choose the level of the output frequency from 
+            Choose the level of the output frequency from
             0 (no output) or 1 (normal output).
 
         """
@@ -262,7 +262,7 @@ class ALM:
             The mapping information of atoms from the primitive cell to the supercell.
 
         """
-        
+
         if self._id is None:
             self._show_error_message()
 
@@ -326,7 +326,7 @@ class ALM:
         ----------
         fc_order : int
             The order of force constants to get.
-            
+
             - If ``fc_order = 1``, returns harmonic force constants.
             - If ``fc_order = 2``, returns cubic force constants.
             - If ``fc_order = 3``, returns quartic force constants.
@@ -336,7 +336,7 @@ class ALM:
             The choice of the force constant list to be returned.
 
             - If "origin", returns the reducible set of force constants,
-              whose first element corresponds to an atom in the 
+              whose first element corresponds to an atom in the
               primitive cell at the origin.
             - If "irreducible" or "irred", returns the irreducible set of
               force constants.
@@ -472,7 +472,7 @@ class ALM:
 
         amat = np.zeros(3 * nat * ndata_used * fc_length, dtype='double')
         bvec = np.zeros(3 * nat * ndata_used)
-        alm.get_matrix_elements(self._id, nat, ndata_used, amat, bvec)
+        alm.get_matrix_elements(self._id, ndata_used, amat, bvec)
 
         return np.reshape(amat, (3 * nat * ndata_used, fc_length), order='F'), bvec
 
@@ -504,7 +504,7 @@ class ALM:
 
     def _get_number_of_displacement_patterns(self, fc_order):
         """Private method to return the number of displacement patterns
-        
+
         Parameters
         ----------
         fc_order : int
@@ -517,7 +517,7 @@ class ALM:
 
     def _get_number_of_displaced_atoms(self, fc_order):
         """Private method to return the number of displaced atoms
-        
+
         Parameters
         ----------
         fc_order : int
@@ -534,7 +534,7 @@ class ALM:
 
     def _get_number_of_fc_elements(self, fc_order):
         """Private method to get the number of force constants
-        
+
         Parameters
         ----------
         fc_order : int
@@ -547,7 +547,7 @@ class ALM:
 
     def _get_number_of_irred_fc_elements(self, fc_order):
         """Private method to get the number of irreducible set of force constants
-        
+
         Parameters
         ----------
         fc_order : int

--- a/python/alm/alm.py
+++ b/python/alm/alm.py
@@ -1,6 +1,5 @@
 import numpy as np
 from . import _alm as alm
-import warnings
 
 
 class ALM:

--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -124,7 +124,7 @@ extern "C" {
         alm[id]->set_verbosity(verbosity);
     }
 
-    // void set_magnetic_params(const double* magmom,
+    // void set_magnetic_params(const double* const * magmom,
     //   		       const bool lspin,
     //   		       const int noncollinear,
     //   		       const int trev_sym_mag,

--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -119,7 +119,7 @@ extern "C" {
         delete [] kdname;
     }
 
-    void alm_set_verbosity(const int id, const int verbosity) 
+    void alm_set_verbosity(const int id, const int verbosity)
     {
         alm[id]->set_verbosity(verbosity);
     }
@@ -193,7 +193,7 @@ extern "C" {
                                            int *numbers,
                                            const int fc_order) // harmonic=1,
     {
-        alm[id]->get_number_of_displaced_atoms(numbers, fc_order);        
+        alm[id]->get_number_of_displaced_atoms(numbers, fc_order);
     }
 
     int alm_get_displacement_patterns(const int id,
@@ -248,12 +248,11 @@ extern "C" {
     }
 
     void alm_get_matrix_elements(const int id,
-                                 const int nat,
                                  const int ndata_used,
                                  double *amat,
                                  double *bvec)
     {
-        alm[id]->get_matrix_elements(nat, ndata_used, amat, bvec);
+        alm[id]->get_matrix_elements(ndata_used, amat, bvec);
     }
 
     void alm_run_suggest(const int id)
@@ -270,7 +269,7 @@ extern "C" {
         int info;
 
         if (str_solver == "dense") {
-            
+
             alm[id]->set_sparse_mode(0);
             info = alm[id]->optimize();
 

--- a/python/alm_wrapper.h
+++ b/python/alm_wrapper.h
@@ -23,7 +23,7 @@ extern "C" {
                       const int kd[]);
     void alm_set_verbosity(const int id,
                            const int verbosity);
-    // void set_magnetic_params(const double* magmom,
+    // void set_magnetic_params(const double* const * magmom,
     //   		       const bool lspin,
     //   		       const int noncollinear,
     //   		       const int trev_sym_mag,

--- a/python/alm_wrapper.h
+++ b/python/alm_wrapper.h
@@ -1,8 +1,8 @@
 #ifndef __ALM_WRAPPER_H__
 #define __ALM_WRAPPER_H__
 
-#ifdef __cplusplus 
-extern "C" { 
+#ifdef __cplusplus
+extern "C" {
 #endif
 
     void alm_init(void);
@@ -81,16 +81,15 @@ extern "C" {
     void alm_set_fc(const int id, double *fc_in);
 
     void alm_get_matrix_elements(const int id,
-                                 const int nat,
                                  const int ndata_used,
                                  double *amat,
                                  double *bvec);
 
     void alm_run_suggest(const int id);
-    int alm_optimize(const int id, 
+    int alm_optimize(const int id,
                      const char *solver);
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/alm.cpp
+++ b/src/alm.cpp
@@ -39,10 +39,6 @@ ALM::ALM()
 
 ALM::~ALM()
 {
-    if (system->magmom) {
-        deallocate(system->magmom);
-    }
-    system->magmom = nullptr;
     if (interaction->nbody_include) {
         deallocate(interaction->nbody_include);
     }
@@ -164,21 +160,12 @@ void ALM::set_cell(const int nat,
         }
     }
 
-    if (system->magmom) {
-        deallocate(system->magmom);
-    }
-    allocate(system->magmom, nat, 3);
-    for (i = 0; i < nat; ++i) {
-        for (j = 0; j < 3; ++j) {
-            system->magmom[i][j] = 0.0;
-        }
-    }
-
     // Generate the information of the supercell
-    system->set_supercell(lavec, nat, nkd, kd, xcoord, kdname);
+    system->set_supercell(lavec, nat, nkd, kd, xcoord);
+    system->set_kdname(kdname);
 }
 
-void ALM::set_magnetic_params(const double *magmom,
+void ALM::set_magnetic_params(const double (*magmom)[3],
                               // MAGMOM
                               const bool lspin,
                               const int noncollinear,
@@ -187,22 +174,11 @@ void ALM::set_magnetic_params(const double *magmom,
                               // TREVSYM
                               const std::string str_magmom) const // MAGMOM
 {
-    const auto nat = system->get_supercell().number_of_atoms;
-    system->lspin = lspin;
-    system->noncollinear = noncollinear;
-    system->str_magmom = str_magmom;
-    system->trev_sym_mag = trev_sym_mag;
-
-    if (system->magmom) {
-        deallocate(system->magmom);
-    }
-    allocate(system->magmom, nat, 3);
-
-    for (int i = 0; i < nat; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            system->magmom[i][j] = magmom[i * 3 + j];
-        }
-    }
+    system->set_spin_variables(lspin,
+                               noncollinear,
+                               trev_sym_mag,
+                               magmom);
+    system->set_str_magmom(str_magmom);
 }
 
 void ALM::set_displacement_and_force(const double *u_in,

--- a/src/alm.cpp
+++ b/src/alm.cpp
@@ -39,10 +39,6 @@ ALM::ALM()
 
 ALM::~ALM()
 {
-    if (system->kdname) {
-        deallocate(system->kdname);
-    }
-    system->kdname = nullptr;
     if (system->magmom) {
         deallocate(system->magmom);
     }
@@ -139,9 +135,7 @@ void ALM::set_displacement_basis(const std::string str_disp_basis) const // DBAS
 
 void ALM::set_periodicity(const int is_periodic[3]) const // PERIODIC
 {
-    for (int i = 0; i < 3; ++i) {
-        system->is_periodic[i] = is_periodic[i];
-    }
+    system->set_periodicity(is_periodic);
 }
 
 void ALM::set_cell(const int nat,
@@ -170,14 +164,6 @@ void ALM::set_cell(const int nat,
         }
     }
 
-    if (system->kdname) {
-        deallocate(system->kdname);
-    }
-    allocate(system->kdname, nkd);
-    for (i = 0; i < nkd; ++i) {
-        system->kdname[i] = kdname[i];
-    }
-
     if (system->magmom) {
         deallocate(system->magmom);
     }
@@ -189,7 +175,7 @@ void ALM::set_cell(const int nat,
     }
 
     // Generate the information of the supercell
-    system->set_supercell(lavec, nat, nkd, kd, xcoord);
+    system->set_supercell(lavec, nat, nkd, kd, xcoord, kdname);
 }
 
 void ALM::set_magnetic_params(const double *magmom,

--- a/src/alm.h
+++ b/src/alm.h
@@ -58,11 +58,11 @@ namespace ALM_NS
                       const double xcoord[][3],
                       const int kd[],
                       const std::string kdname[]) const;
-        void set_magnetic_params(const double *magmom,
-                                 bool lspin,
-                                 int noncollinear,
-                                 int trev_sym_mag,
-                                 std::string str_magmom) const;
+        void set_magnetic_params(const double (*magmom)[3],
+                                 const bool lspin,
+                                 const int noncollinear,
+                                 const int trev_sym_mag,
+                                 const std::string str_magmom) const;
         void set_displacement_and_force(const double *u_in,
                                         const double *f_in,
                                         int nat,

--- a/src/alm.h
+++ b/src/alm.h
@@ -106,8 +106,7 @@ namespace ALM_NS
 
         void set_fc(double *fc_in) const;
 
-        void get_matrix_elements(int nat,
-                                 int ndata_used,
+        void get_matrix_elements(const int ndata_used,
                                  double *amat,
                                  double *bvec) const;
         void generate_force_constant();

--- a/src/alm_cui.cpp
+++ b/src/alm_cui.cpp
@@ -62,6 +62,7 @@ void ALMCUI::run(int narg,
     if (alm->get_run_mode() == "fitting" || alm->get_run_mode() == "lasso") {
         input_parser->parse_displacement_and_force(alm);
     }
+
     delete input_parser;
 
     alm->run();

--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -1218,7 +1218,7 @@ void Constraint::generate_rotational_constraint(const System *system,
                                     for (j = 0; j < nsize_equiv; ++j) {
                                         for (int k = 0; k < 3; ++k) {
                                             vec_for_rot[k]
-                                                += system->x_image[(*iter_cluster).cell[j][0]][jat][k];
+                                                += system->get_x_image()[(*iter_cluster).cell[j][0]][jat][k];
                                         }
                                     }
 
@@ -1358,7 +1358,7 @@ void Constraint::generate_rotational_constraint(const System *system,
 
                                                 for (j = 0; j < nsize_equiv; ++j) {
                                                     for (int k = 0; k < 3; ++k) {
-                                                        vec_for_rot[k] += system->x_image[(*iter_cluster).cell[j][
+                                                        vec_for_rot[k] += system->get_x_image()[(*iter_cluster).cell[j][
                                                             iloc]][jat][k];
                                                     }
                                                 }

--- a/src/input_parser.cpp
+++ b/src/input_parser.cpp
@@ -906,7 +906,7 @@ void InputParser::parse_atomic_positions(ALM *alm)
     std::string str_tmp;
     std::string::size_type pos_first_comment_tag;
     std::vector<std::string> str_v, pos_line;
-    double **xeq;
+    double (*xeq)[3];
     int *kd;
 
     if (from_stdin) {
@@ -962,7 +962,7 @@ void InputParser::parse_atomic_positions(ALM *alm)
              "The number of entries for atomic positions should be NAT");
     }
 
-    allocate(xeq, nat, 3);
+    allocate(xeq, nat);
     allocate(kd, nat);
 
 

--- a/src/input_parser.cpp
+++ b/src/input_parser.cpp
@@ -189,7 +189,7 @@ void InputParser::parse_input(ALM *alm)
              "&position entry not found in the input file");
     }
     parse_atomic_positions(alm);
-    input_setter->set_cell(alm);
+    input_setter->set_geometric_structure(alm);
 
     if (!locate_tag("&interaction")) {
         exit("parse_input",

--- a/src/input_setter.cpp
+++ b/src/input_setter.cpp
@@ -64,7 +64,7 @@ void InputSetter::set_general_vars(ALM *alm,
                                    const int nat_in,
                                    const int nkd_in,
                                    const int printsymmetry,
-                                   const int is_periodic[3],
+                                   const int is_periodic_in[3],
                                    const bool trim_dispsign_for_evenfunc,
                                    const bool lspin,
                                    const bool print_hessian,
@@ -97,9 +97,10 @@ void InputSetter::set_general_vars(ALM *alm,
 
     allocate(alm->system->magmom, nat_in, 3);
 
-    for (i = 0; i < 3; ++i) {
-        alm->system->is_periodic[i] = is_periodic[i];
+    for (i = 0; i < 3; i++) {
+        is_periodic[i] = is_periodic_in[i];
     }
+
     for (i = 0; i < nat_in; ++i) {
         for (j = 0; j < 3; ++j) {
             alm->system->magmom[i][j] = magmom[i][j];
@@ -267,7 +268,8 @@ void InputSetter::set_atomic_positions(const int nat_in,
     }
 }
 
-void InputSetter::set_cell(ALM *alm) const
+void InputSetter::set_geometric_structure(ALM *alm) const
 {
     alm->set_cell(nat, lavec, xcoord, kd, kdname);
+    alm->set_periodicity(is_periodic);
 }

--- a/src/input_setter.h
+++ b/src/input_setter.h
@@ -93,7 +93,7 @@ namespace ALM_NS
         void set_atomic_positions(const int nat_in,
                                   const int *kd_in,
                                   const double * const *xcoord_in);
-        void set_cell(ALM *alm) const;
+        void set_geometric_structure(ALM *alm) const;
 
     private:
         int nat, nkd;
@@ -101,6 +101,7 @@ namespace ALM_NS
         double lavec[3][3];
         double (*xcoord)[3]; // fractional coordinate
         std::string *kdname;
+        int is_periodic[3];
 
     };
 }

--- a/src/input_setter.h
+++ b/src/input_setter.h
@@ -92,7 +92,7 @@ namespace ALM_NS
                             std::string ffile_test) const;
         void set_atomic_positions(const int nat_in,
                                   const int *kd_in,
-                                  const double * const *xcoord_in);
+                                  const double (*xcoord_in)[3]);
         void set_geometric_structure(ALM *alm) const;
 
     private:
@@ -103,5 +103,10 @@ namespace ALM_NS
         std::string *kdname;
         int is_periodic[3];
 
+        bool lspin;
+        double (*magmom)[3];
+        int noncollinear;
+        int trevsym;
+        std::string str_magmom;
     };
 }

--- a/src/interaction.cpp
+++ b/src/interaction.cpp
@@ -156,9 +156,9 @@ void Interaction::init(const System *system,
 }
 
 void Interaction::generate_pairs(const int natmin,
-                                 int **map_p2s,
+                                 const int * const *map_p2s,
                                  std::set<IntList> *pair_out,
-                                 std::set<InteractionCluster> **interaction_cluster) const
+                                 const std::set<InteractionCluster> * const *interaction_cluster) const
 {
     int i, j;
     int iat;
@@ -224,8 +224,8 @@ void Interaction::deallocate_variables()
     }
 }
 
-double Interaction::distance(double *x1,
-                             double *x2) const
+double Interaction::distance(const double *x1,
+                             const double *x2) const
 {
     double dist;
     dist = std::pow(x1[0] - x2[0], 2) + std::pow(x1[1] - x2[1], 2) + std::pow(x1[2] - x2[2], 2);
@@ -234,9 +234,9 @@ double Interaction::distance(double *x1,
     return dist;
 }
 
-void Interaction::get_pairs_of_minimum_distance(int nat,
-                                                double ***xc_in,
-                                                int *exist) const
+void Interaction::get_pairs_of_minimum_distance(const int nat,
+                                                const double * const * const *xc_in,
+                                                const int *exist)
 {
     //
     // Calculate the minimum distance between atom i and j
@@ -290,9 +290,9 @@ void Interaction::get_pairs_of_minimum_distance(int nat,
 
 void Interaction::print_neighborlist(const int nat,
                                      const int natmin,
-                                     int **map_p2s,
+                                     const int * const * map_p2s,
                                      const std::vector<int> &kd,
-                                     std::string *kdname) const
+                                     const std::string *kdname) const
 {
     //
     // Print the list of neighboring atoms and distances
@@ -409,8 +409,8 @@ void Interaction::print_neighborlist(const int nat,
 void Interaction::generate_interaction_information_by_cutoff(const int nat,
                                                              const int natmin,
                                                              const std::vector<int> &kd,
-                                                             int **map_p2s,
-                                                             double **rc,
+                                                             const int * const *map_p2s,
+                                                             const double * const * rc,
                                                              std::vector<int> *interaction_list) const
 {
     int i, iat, jat, ikd, jkd;
@@ -447,8 +447,8 @@ void Interaction::generate_interaction_information_by_cutoff(const int nat,
 void Interaction::set_interaction_by_cutoff(const unsigned int nat,
                                             const std::vector<int> &kd,
                                             const unsigned int nat_prim,
-                                            int **map_p2s_in,
-                                            double ***rcs,
+                                            const int * const * map_p2s_in,
+                                            const double * const * const *rcs,
                                             std::vector<int> **interaction_pair_out) const
 {
     for (int order = 0; order < maxorder; ++order) {
@@ -462,10 +462,10 @@ void Interaction::set_interaction_by_cutoff(const unsigned int nat,
 }
 
 void Interaction::print_interaction_information(const int natmin,
-                                                int **map_p2s,
+                                                const int * const *map_p2s,
                                                 const std::vector<int> &kd,
-                                                std::string *kdname,
-                                                std::vector<int> **interaction_list)
+                                                const std::string *kdname,
+                                                const std::vector<int> * const *interaction_list)
 {
     int order;
     int i, iat;
@@ -494,7 +494,6 @@ void Interaction::print_interaction_information(const int natmin,
             std::sort(intlist.begin(), intlist.end());
 
             // write atoms inside the cutoff radius
-            int id = 0;
             std::cout << "    Atom " << std::setw(5) << iat + 1
                 << "(" << std::setw(3) << kdname[kd[iat] - 1]
                 << ")" << " interacts with atoms ... " << std::endl;
@@ -616,10 +615,10 @@ void Interaction::calc_interaction_clusters(const int natmin,
 void Interaction::set_interaction_cluster(const int order,
                                           const int natmin,
                                           const std::vector<int> &kd,
-                                          int **map_p2s,
-                                          std::vector<int> *interaction_pair_in,
-                                          double ***x_image,
-                                          int *exist,
+                                          const int * const *map_p2s,
+                                          const std::vector<int> *interaction_pair_in,
+                                          const double * const * const *x_image,
+                                          const int *exist,
                                           std::set<InteractionCluster> *interaction_cluster_out) const
 {
     //
@@ -854,7 +853,7 @@ void Interaction::set_interaction_cluster(const int order,
 
 void Interaction::cell_combination(const std::vector<std::vector<int>> &array,
                                    const int i,
-                                   std::vector<int> accum,
+                                   const std::vector<int> accum,
                                    std::vector<std::vector<int>> &comb) const
 {
     if (i == array.size()) {

--- a/src/interaction.cpp
+++ b/src/interaction.cpp
@@ -126,14 +126,14 @@ void Interaction::init(const System *system,
                            symmetry->nat_prim,
                            symmetry->map_p2s,
                            system->get_supercell().kind,
-                           system->kdname);
+                           system->get_kdname());
     }
 
     if (verbosity > 1) {
         print_interaction_information(symmetry->nat_prim,
                                       symmetry->map_p2s,
                                       system->get_supercell().kind,
-                                      system->kdname,
+                                      system->get_kdname(),
                                       interaction_pair);
     }
 
@@ -588,10 +588,10 @@ bool Interaction::satisfy_nbody_rule(const int nelem,
 
 void Interaction::calc_interaction_clusters(const int natmin,
                                             const std::vector<int> &kd,
-                                            int **map_p2s,
-                                            std::vector<int> **interaction_pair_in,
-                                            double ***x_image,
-                                            int *exist,
+                                            const int * const *map_p2s,
+                                            const std::vector<int> * const *interaction_pair_in,
+                                            const double * const * const *x_image,
+                                            const int *exist,
                                             std::set<InteractionCluster> **interaction_cluster_out)
 {
     //

--- a/src/interaction.cpp
+++ b/src/interaction.cpp
@@ -80,8 +80,8 @@ void Interaction::init(const System *system,
     allocate(cluster_list, maxorder);
 
     get_pairs_of_minimum_distance(nat,
-                                  system->x_image,
-                                  system->exist_image);
+                                  system->get_x_image(),
+                                  system->get_exist_image());
 
     set_interaction_by_cutoff(system->get_supercell().number_of_atoms,
                               system->get_supercell().kind,
@@ -94,8 +94,8 @@ void Interaction::init(const System *system,
                               system->get_supercell().kind,
                               symmetry->map_p2s,
                               interaction_pair,
-                              system->x_image,
-                              system->exist_image,
+                              system->get_x_image(),
+                              system->get_exist_image(),
                               interaction_cluster);
 
     generate_pairs(symmetry->nat_prim,

--- a/src/interaction.h
+++ b/src/interaction.h
@@ -210,18 +210,18 @@ namespace ALM_NS
                          const int,
                          const std::vector<int> &) const;
 
-        void generate_interaction_information_by_cutoff(int,
-                                                        int,
+        void generate_interaction_information_by_cutoff(const int,
+                                                        const int,
                                                         const std::vector<int> &,
-                                                        int **,
-                                                        double **,
+                                                        const int * const *,
+                                                        const double * const *,
                                                         std::vector<int> *) const;
 
-        void set_interaction_by_cutoff(unsigned int,
+        void set_interaction_by_cutoff(const unsigned int,
                                        const std::vector<int> &,
-                                       unsigned int,
-                                       int **,
-                                       double ***,
+                                       const unsigned int,
+                                       const int * const *,
+                                       const double * const * const *,
                                        std::vector<int> **) const;
 
 
@@ -233,27 +233,29 @@ namespace ALM_NS
         void set_default_variables();
         void deallocate_variables();
 
-        void get_pairs_of_minimum_distance(int,
-                                           double ***,
-                                           int *) const;
+        // can be made const function, but mindist_pairs is modified
+        // in this function.
+        void get_pairs_of_minimum_distance(const int,
+                                           const double * const * const *,
+                                           const int *);
 
-        void print_neighborlist(int,
-                                int,
-                                int **,
+        void print_neighborlist(const int,
+                                const int,
+                                const int * const *,
                                 const std::vector<int> &,
-                                std::string *) const;
+                                const std::string *) const;
 
-        void print_interaction_information(int,
-                                           int **,
+        void print_interaction_information(const int,
+                                           const int * const *,
                                            const std::vector<int> &,
-                                           std::string *,
-                                           std::vector<int> **);
+                                           const std::string *,
+                                           const std::vector<int> * const *);
 
         void set_ordername();
-        double distance(double *, double *) const;
+        double distance(const double *, const double *) const;
         int nbody(const int, const int *) const;
 
-        void calc_interaction_clusters(int,
+        void calc_interaction_clusters(const int,
                                        const std::vector<int> &,
                                        int **,
                                        std::vector<int> **,
@@ -261,24 +263,24 @@ namespace ALM_NS
                                        int *,
                                        std::set<InteractionCluster> **);
 
-        void set_interaction_cluster(int,
-                                     int,
+        void set_interaction_cluster(const int,
+                                     const int,
                                      const std::vector<int> &,
-                                     int **,
-                                     std::vector<int> *,
-                                     double ***,
-                                     int *,
+                                     const int * const *,
+                                     const std::vector<int> *,
+                                     const double * const * const*,
+                                     const int *,
                                      std::set<InteractionCluster> *) const;
 
         void cell_combination(const std::vector<std::vector<int>> &,
-                              int,
-                              std::vector<int>,
+                              const int,
+                              const std::vector<int>,
                               std::vector<std::vector<int>> &) const;
 
-        void generate_pairs(int,
-                            int **,
+        void generate_pairs(const int,
+                            const int * const *,
                             std::set<IntList> *,
-                            std::set<InteractionCluster> **) const;
+                            const std::set<InteractionCluster> * const *) const;
     };
 }
 

--- a/src/interaction.h
+++ b/src/interaction.h
@@ -257,10 +257,10 @@ namespace ALM_NS
 
         void calc_interaction_clusters(const int,
                                        const std::vector<int> &,
-                                       int **,
-                                       std::vector<int> **,
-                                       double ***,
-                                       int *,
+                                       const int * const *,
+                                       const std::vector<int> * const *,
+                                       const double * const *const *,
+                                       const int *,
                                        std::set<InteractionCluster> **);
 
         void set_interaction_cluster(const int,

--- a/src/symmetry.cpp
+++ b/src/symmetry.cpp
@@ -51,7 +51,7 @@ void Symmetry::init(const System *system,
 
 
     setup_symmetry_operation(system->get_supercell(),
-                             system->is_periodic,
+                             system->get_periodicity(),
                              system->atomtype_group,
                              system->spin,
                              verbosity,

--- a/src/symmetry.cpp
+++ b/src/symmetry.cpp
@@ -52,8 +52,8 @@ void Symmetry::init(const System *system,
 
     setup_symmetry_operation(system->get_supercell(),
                              system->get_periodicity(),
-                             system->atomtype_group,
-                             system->spin,
+                             system->get_atomtype_group(),
+                             system->get_spin(),
                              verbosity,
                              SymmData,
                              nsym,
@@ -81,7 +81,7 @@ void Symmetry::init(const System *system,
     allocate(map_p2s, nat_prim, ntran);
 
     gen_mapping_information(system->get_supercell(),
-                            system->atomtype_group,
+                            system->get_atomtype_group(),
                             SymmData,
                             symnum_tran,
                             map_sym, map_p2s, map_s2p);
@@ -648,8 +648,6 @@ void Symmetry::symop_in_cart(double rot_cart[3][3],
 
 void Symmetry::print_symminfo_stdout() const
 {
-    int i;
-
     std::cout << "  Number of symmetry operations = " << SymmData.size() << std::endl;
     std::cout << std::endl;
     if (ntran > 1) {
@@ -748,9 +746,6 @@ void Symmetry::gen_mapping_information(const Cell &cell,
             }
         }
     }
-
-    double shift[3];
-    double pos[3], pos_std[3];
 
     // Generate map_p2s (primitive --> super)
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -33,6 +33,8 @@ System::~System()
 void System::init(const int verbosity,
                   Timer *timer)
 {
+    const unsigned int nat = supercell.number_of_atoms;
+
     timer->start_clock("system");
 
     // Generate the information of spins
@@ -74,9 +76,10 @@ void System::set_supercell(const double lavec_in[3][3],
                            const unsigned int nat_in,
                            const unsigned int nkd_in,
                            const int *kd_in,
-                           const double * const *xf_in)
+                           const double xf_in[][3])
 {
     unsigned int i, j;
+
     for (i = 0; i < 3; ++i) {
         for (j = 0; j < 3; ++j) {
             supercell.lattice_vector[i][j] = lavec_in[i][j];
@@ -93,6 +96,7 @@ void System::set_supercell(const double lavec_in[3][3],
     supercell.x_cartesian.shrink_to_fit();
 
     std::vector<double> xtmp;
+
     xtmp.resize(3);
     for (i = 0; i < nat_in; ++i) {
         supercell.kind.push_back(kd_in[i]);
@@ -173,7 +177,7 @@ void System::frac2cart(double **xf) const
     double *x_tmp;
     allocate(x_tmp, 3);
 
-    for (int i = 0; i < nat; ++i) {
+    for (int i = 0; i < supercell.number_of_atoms; ++i) {
 
         rotvec(x_tmp, xf[i], supercell.lattice_vector);
 
@@ -216,17 +220,7 @@ double System::volume(const double latt_in[3][3],
 void System::set_default_variables()
 {
     // Default values
-    nat = 0;
-    nkd = 0;
-    kd = nullptr;
     kdname = nullptr;
-
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; j++) {
-            lavec[i][j] = 0.0;
-        }
-    }
-    xcoord = nullptr;
     is_periodic[0] = 1;
     is_periodic[1] = 1;
     is_periodic[2] = 1;
@@ -241,14 +235,8 @@ void System::set_default_variables()
 
 void System::deallocate_variables()
 {
-    if (kd) {
-        deallocate(kd);
-    }
     if (kdname) {
         deallocate(kdname);
-    }
-    if (xcoord) {
-        deallocate(xcoord);
     }
     if (magmom) {
         deallocate(magmom);

--- a/src/system.h
+++ b/src/system.h
@@ -61,17 +61,22 @@ namespace ALM_NS
     public:
         System();
         ~System();
-        void init(const int verbosity,
-                  Timer *timer);
+        void init(const int,
+                  Timer *);
         void frac2cart(double **) const;
 
         void set_supercell(const double [3][3],
                            const unsigned int,
                            const unsigned int,
                            const int *,
-                           const double [][3]);
-
+                           const double [][3],
+                           const std::string []);
         Cell get_supercell() const;
+        double *** get_x_image() const;
+        int * get_exist_image() const;
+        void set_periodicity(const int [3]);
+        int * get_periodicity() const;
+        std::string * get_kdname() const;
 
         void set_spin_variable(const bool,
                                const int,
@@ -81,10 +86,8 @@ namespace ALM_NS
 
         Spin spin;
 
-        std::string *kdname;
         // concatenate atomic kind and magmom (only for collinear case)
         std::vector<std::vector<unsigned int>> atomtype_group;
-        int is_periodic[3];
         double ***x_image;
         int *exist_image;
 
@@ -98,6 +101,8 @@ namespace ALM_NS
 
     private:
         Cell supercell;
+        std::string *kdname;
+        int *is_periodic;  // is_periodic[3];
 
         enum LatticeType { Direct, Reciprocal };
 
@@ -108,11 +113,7 @@ namespace ALM_NS
         double volume(const double [3][3], LatticeType) const;
         void set_atomtype_group();
 
-        void generate_coordinate_of_periodic_images(const unsigned int,
-                                                    const std::vector<std::vector<double>> &,
-                                                    const int [3],
-                                                    double ***,
-                                                    int *) const;
+        void generate_coordinate_of_periodic_images();
         void print_structure_stdout(const Cell &);
         void print_magmom_stdout() const;
     };

--- a/src/system.h
+++ b/src/system.h
@@ -88,8 +88,6 @@ namespace ALM_NS
 
         // concatenate atomic kind and magmom (only for collinear case)
         std::vector<std::vector<unsigned int>> atomtype_group;
-        double ***x_image;
-        int *exist_image;
 
         // Variables for spins
 
@@ -103,6 +101,9 @@ namespace ALM_NS
         Cell supercell;
         std::string *kdname;
         int *is_periodic;  // is_periodic[3];
+
+        double ***x_image;
+        int *exist_image;
 
         enum LatticeType { Direct, Reciprocal };
 

--- a/src/system.h
+++ b/src/system.h
@@ -69,7 +69,7 @@ namespace ALM_NS
                            const unsigned int,
                            const unsigned int,
                            const int *,
-                           const double * const *);
+                           const double [][3]);
 
         Cell get_supercell() const;
 
@@ -95,13 +95,6 @@ namespace ALM_NS
         int noncollinear;
         double **magmom;
         std::string str_magmom;
-
-        // Referenced from input_setter, writer
-
-        int nat, nkd;
-        int *kd;
-        double lavec[3][3];
-        double **xcoord; // fractional coordinate
 
     private:
         Cell supercell;

--- a/src/system.h
+++ b/src/system.h
@@ -69,41 +69,40 @@ namespace ALM_NS
                            const unsigned int,
                            const unsigned int,
                            const int *,
-                           const double [][3],
-                           const std::string []);
+                           const double [][3]);
         Cell get_supercell() const;
         double *** get_x_image() const;
         int * get_exist_image() const;
         void set_periodicity(const int [3]);
         int * get_periodicity() const;
         std::string * get_kdname() const;
+        void set_kdname(const std::string *);
+        void set_periodicity(bool);
 
-        void set_spin_variable(const bool,
-                               const int,
-                               const int,
-                               const unsigned int,
-                               double **);
+        void set_spin_variables(const bool,
+                                const int,
+                                const int,
+                                const double (*)[3]);
+        Spin get_spin() const;
+        void set_str_magmom(std::string);
+        std::string get_str_magmom() const;
 
-        Spin spin;
-
-        // concatenate atomic kind and magmom (only for collinear case)
-        std::vector<std::vector<unsigned int>> atomtype_group;
-
-        // Variables for spins
-
-        bool lspin;
-        int trev_sym_mag;
-        int noncollinear;
-        double **magmom;
-        std::string str_magmom;
+        std::vector<std::vector<unsigned int>> get_atomtype_group() const;
 
     private:
+        // Variables for geometric structure
         Cell supercell;
         std::string *kdname;
         int *is_periodic;  // is_periodic[3];
-
         double ***x_image;
         int *exist_image;
+
+        // Variables for spins
+        Spin spin;
+        std::string str_magmom;
+
+        // concatenate atomic kind and magmom (only for collinear case)
+        std::vector<std::vector<unsigned int>> atomtype_group;
 
         enum LatticeType { Direct, Reciprocal };
 

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -55,10 +55,10 @@ void Writer::write_input_vars(const ALM *alm) const
     std::cout << "  PRINTSYM = " << alm->symmetry->printsymmetry
         << "; TOLERANCE = " << alm->symmetry->tolerance << std::endl;
     std::cout << "  KD = ";
-    for (i = 0; i < nkd; ++i) std::cout << std::setw(4) << alm->system->kdname[i];
+    for (i = 0; i < nkd; ++i) std::cout << std::setw(4) << alm->system->get_kdname()[i];
     std::cout << std::endl;
     std::cout << "  PERIODIC = ";
-    for (i = 0; i < 3; ++i) std::cout << std::setw(3) << alm->system->is_periodic[i];
+    for (i = 0; i < 3; ++i) std::cout << std::setw(3) << alm->system->get_periodicity()[i];
     std::cout << std::endl;
     std::cout << "  MAGMOM = " << alm->system->str_magmom << std::endl;
     std::cout << "  HESSIAN = " << alm->files->print_hessian << std::endl;
@@ -416,7 +416,7 @@ void Writer::write_misc_xml(ALM *alm)
 
     for (i = 0; i < system_structure.nspecies; ++i) {
         ptree &child = pt.add("Data.Structure.AtomicElements.element",
-                              alm->system->kdname[i]);
+                              alm->system->get_kdname()[i]);
         child.put("<xmlattr>.number", i + 1);
     }
 
@@ -432,9 +432,9 @@ void Writer::write_misc_xml(ALM *alm)
     pt.put("Data.Structure.LatticeVector.a3", str_pos[2]);
 
     std::stringstream ss;
-    ss << alm->system->is_periodic[0] << " "
-        << alm->system->is_periodic[1] << " "
-        << alm->system->is_periodic[2];
+    ss << alm->system->get_periodicity()[0] << " "
+        << alm->system->get_periodicity()[1] << " "
+        << alm->system->get_periodicity()[2];
     pt.put("Data.Structure.Periodicity", ss.str());
 
     pt.put("Data.Structure.Position", "");
@@ -445,7 +445,7 @@ void Writer::write_misc_xml(ALM *alm)
         for (j = 0; j < 3; ++j) str_tmp += " " + double2string(alm->system->get_supercell().x_fractional[i][j]);
         ptree &child = pt.add("Data.Structure.Position.pos", str_tmp);
         child.put("<xmlattr>.index", i + 1);
-        child.put("<xmlattr>.element", alm->system->kdname[alm->system->get_supercell().kind[i] - 1]);
+        child.put("<xmlattr>.element", alm->system->get_kdname()[alm->system->get_supercell().kind[i] - 1]);
     }
 
     pt.put("Data.Symmetry.NumberOfTranslations", alm->symmetry->ntran);

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -60,7 +60,7 @@ void Writer::write_input_vars(const ALM *alm) const
     std::cout << "  PERIODIC = ";
     for (i = 0; i < 3; ++i) std::cout << std::setw(3) << alm->system->get_periodicity()[i];
     std::cout << std::endl;
-    std::cout << "  MAGMOM = " << alm->system->str_magmom << std::endl;
+    std::cout << "  MAGMOM = " << alm->system->get_str_magmom() << std::endl;
     std::cout << "  HESSIAN = " << alm->files->print_hessian << std::endl;
     std::cout << std::endl;
 
@@ -458,13 +458,13 @@ void Writer::write_misc_xml(ALM *alm)
         }
     }
 
-    if (alm->system->lspin) {
+    if (alm->system->get_spin().lspin) {
         pt.put("Data.MagneticMoments", "");
-        pt.put("Data.MagneticMoments.Noncollinear", alm->system->noncollinear);
-        pt.put("Data.MagneticMoments.TimeReversalSymmetry", alm->system->trev_sym_mag);
+        pt.put("Data.MagneticMoments.Noncollinear", alm->system->get_spin().noncollinear);
+        pt.put("Data.MagneticMoments.TimeReversalSymmetry", alm->system->get_spin().time_reversal_symm);
         for (i = 0; i < system_structure.nat; ++i) {
             str_tmp.clear();
-            for (j = 0; j < 3; ++j) str_tmp += " " + double2string(alm->system->magmom[i][j], 5);
+            for (j = 0; j < 3; ++j) str_tmp += " " + double2string(alm->system->get_spin().magmom[i][j], 5);
             ptree &child = pt.add("Data.MagneticMoments.mag", str_tmp);
             child.put("<xmlattr>.index", i + 1);
         }


### PR DESCRIPTION
All the public variables of the System class were made private. Many lines were changed, but what was done is simple. Please carefully check the design of the setter and getter of private varials in System class. `**xcoord` and `**magmom` in class setters were changed to `(*xcoord)[3]` and `(*magmom)[3]`.