### PR TITLE
Work in symmetry

### DIFF
--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -199,17 +199,21 @@ extern "C" {
                                                   int *map_p2s)
     {
         unsigned int count = 0;
+        unsigned int ntran, nat_prim;
 
         const std::vector<std::vector<int>> map_p2s_vv = alm[id]->get_atom_mapping_by_pure_translations();
 
-        for (const auto &map_p2s_at_nat_prim : map_p2s_vv) {
-            for (const auto trans : map_p2s_at_nat_prim) {
-                map_p2s[count] = trans;
+        nat_prim = map_p2s_vv.size();
+        ntran = map_p2s_vv[0].size();
+
+        for (unsigned int i = 0; i < ntran; i++) {
+            for (unsigned int j = 0; j < nat_prim; j++) {
+                map_p2s[count] = map_p2s_vv[j][i];
                 count++;
             }
         }
 
-        return map_p2s_vv[0].size();
+        return ntran;
     }
 
     int alm_get_number_of_displacement_patterns(const int id,

--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -198,7 +198,17 @@ extern "C" {
     int alm_get_atom_mapping_by_pure_translations(const int id,
                                                   int *map_p2s)
     {
-        return alm[id]->get_atom_mapping_by_pure_translations(map_p2s);
+        unsigned int count = 0;
+
+        const std::vector<std::vector<int>> map_p2s_vv = alm[id]->get_atom_mapping_by_pure_translations();
+
+        for (const auto &map_p2s_at_nat_prim : map_p2s_vv) {
+            for (const auto trans : map_p2s_at_nat_prim) {
+                map_p2s[count] = trans;
+            }
+        }
+
+        return map_p2s_vv[0].size();
     }
 
     int alm_get_number_of_displacement_patterns(const int id,

--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -205,6 +205,7 @@ extern "C" {
         for (const auto &map_p2s_at_nat_prim : map_p2s_vv) {
             for (const auto trans : map_p2s_at_nat_prim) {
                 map_p2s[count] = trans;
+                count++;
             }
         }
 

--- a/src/alm.cpp
+++ b/src/alm.cpp
@@ -85,29 +85,29 @@ int ALM::get_verbosity() const
     return verbosity;
 }
 
-void ALM::set_output_filename_prefix(const std::string prefix) const // PREFIX
+void ALM::set_output_filename_prefix(const std::string prefix) // PREFIX
 {
     files->job_title = prefix;
 }
 
-void ALM::set_is_print_symmetry(const int printsymmetry) const // PRINTSYM
+void ALM::set_print_symmetry(const int printsymmetry) // PRINTSYM
 {
-    symmetry->printsymmetry = printsymmetry;
+    symmetry->set_print_symmetry(printsymmetry);
 }
 
-void ALM::set_is_print_hessians(const bool print_hessian) const // HESSIAN
+void ALM::set_print_hessian(const bool print_hessian) // HESSIAN
 {
     files->print_hessian = print_hessian;
 }
 
 void ALM::set_symmetry_param(const int nsym) const // NSYM
 {
-    symmetry->nsym = nsym;
+    symmetry->set_nsym(nsym);
 }
 
 void ALM::set_symmetry_tolerance(const double tolerance) const // TOLERANCE
 {
-    symmetry->tolerance = tolerance;
+    symmetry->set_tolerance(tolerance);
 }
 
 void ALM::set_displacement_param(const bool trim_dispsign_for_evenfunc) const // TRIMEVEN
@@ -272,17 +272,9 @@ int * ALM::get_periodicity() const
     return system->get_periodicity();
 }
 
-int ALM::get_atom_mapping_by_pure_translations(int *map_p2s) const
+const std::vector<std::vector<int>> &ALM::get_atom_mapping_by_pure_translations() const
 {
-    const int ntran = symmetry->ntran;
-    const int natmin = symmetry->nat_prim;
-
-    for (int i = 0; i < ntran; ++i) {
-        for (int j = 0; j < natmin; ++j) {
-            map_p2s[i * natmin + j] = symmetry->map_p2s[j][i];
-        }
-    }
-    return ntran;
+    return symmetry->get_map_p2s();
 }
 
 int ALM::get_maxorder() const
@@ -484,7 +476,7 @@ void ALM::get_fc_all(double *fc_values,
 {
     int i;
     double fc_elem;
-    const int ntran = symmetry->ntran;
+    const unsigned int ntran = symmetry->get_ntran();
 
     const auto maxorder = interaction->get_maxorder();
     if (fc_order > maxorder) {
@@ -517,7 +509,7 @@ void ALM::get_fc_all(double *fc_values,
 
                 for (int itran = 0; itran < ntran; ++itran) {
                     for (i = 0; i < fc_order + 1; ++i) {
-                        pair_tran[i] = symmetry->map_sym[pair_tmp[i]][symmetry->symnum_tran[itran]];
+                        pair_tran[i] = symmetry->get_map_sym()[pair_tmp[i]][symmetry->get_symnum_tran()[itran]];
                     }
                     fc_values[id] = fc_elem;
                     for (i = 0; i < fc_order + 1; ++i) {

--- a/src/alm.cpp
+++ b/src/alm.cpp
@@ -100,11 +100,6 @@ void ALM::set_print_hessian(const bool print_hessian) // HESSIAN
     files->print_hessian = print_hessian;
 }
 
-void ALM::set_symmetry_param(const int nsym) const // NSYM
-{
-    symmetry->set_nsym(nsym);
-}
-
 void ALM::set_symmetry_tolerance(const double tolerance) const // TOLERANCE
 {
     symmetry->set_tolerance(tolerance);

--- a/src/alm.cpp
+++ b/src/alm.cpp
@@ -34,7 +34,7 @@ ALM::ALM()
     ready_to_fit = false;
     ofs_alm = nullptr;
     coutbuf = nullptr;
-    mode = "suggest";
+    run_mode = "suggest";
 }
 
 ALM::~ALM()
@@ -65,14 +65,14 @@ void ALM::create()
     timer = new Timer();
 }
 
-void ALM::set_run_mode(const std::string mode_in)
+void ALM::set_run_mode(const std::string run_mode_in)
 {
-    mode = mode_in;
+    run_mode = run_mode_in;
 }
 
 std::string ALM::get_run_mode() const
 {
-    return mode;
+    return run_mode;
 }
 
 void ALM::set_verbosity(const int verbosity_in)
@@ -374,7 +374,7 @@ int ALM::get_number_of_irred_fc_elements(const int fc_order) // harmonic=1, ...
                           fcs,
                           interaction,
                           symmetry,
-                          mode,
+                          run_mode,
                           verbosity,
                           timer);
         ready_to_fit = true;
@@ -445,7 +445,7 @@ void ALM::get_fc_irreducible(double *fc_values,
                           fcs,
                           interaction,
                           symmetry,
-                          mode,
+                          run_mode,
                           verbosity,
                           timer);
         ready_to_fit = true;
@@ -569,11 +569,11 @@ void ALM::run()
 {
     generate_force_constant();
 
-    if (mode == "fitting") {
+    if (run_mode == "fitting") {
         optimize();
-    } else if (mode == "suggest") {
+    } else if (run_mode == "suggest") {
         run_suggest();
-    } else if (mode == "lasso") {
+    } else if (run_mode == "lasso") {
         optimize_lasso();
     }
 }
@@ -589,7 +589,7 @@ int ALM::optimize()
                           fcs,
                           interaction,
                           symmetry,
-                          mode,
+                          run_mode,
                           verbosity,
                           timer);
         ready_to_fit = true;
@@ -627,7 +627,7 @@ int ALM::optimize_lasso()
                           fcs,
                           interaction,
                           symmetry,
-                          mode,
+                          run_mode,
                           verbosity,
                           timer);
         ready_to_fit = true;

--- a/src/alm.h
+++ b/src/alm.h
@@ -44,9 +44,9 @@ namespace ALM_NS
         std::string get_run_mode() const;
         void set_verbosity(int verbosity_in);
         int get_verbosity() const;
-        void set_output_filename_prefix(std::string prefix) const;
-        void set_is_print_symmetry(int printsymmetry) const;
-        void set_is_print_hessians(bool print_hessian) const;
+        void set_output_filename_prefix(std::string prefix);
+        void set_print_symmetry(int printsymmetry);
+        void set_print_hessian(bool print_hessian);
         void set_symmetry_param(int nsym) const;
         void set_symmetry_tolerance(double tolerance) const;
         void set_displacement_param(bool trim_dispsign_for_evenfunc) const;
@@ -85,7 +85,7 @@ namespace ALM_NS
         double *** get_x_image() const;
         int * get_periodicity() const;
 
-        int get_atom_mapping_by_pure_translations(int *map_p2s) const;
+        const std::vector<std::vector<int>> &get_atom_mapping_by_pure_translations() const;
         int get_maxorder() const;
         int * get_nbody_include() const;
 

--- a/src/alm.h
+++ b/src/alm.h
@@ -47,7 +47,6 @@ namespace ALM_NS
         void set_output_filename_prefix(std::string prefix);
         void set_print_symmetry(int printsymmetry);
         void set_print_hessian(bool print_hessian);
-        void set_symmetry_param(int nsym) const;
         void set_symmetry_tolerance(double tolerance) const;
         void set_displacement_param(bool trim_dispsign_for_evenfunc) const;
         void set_displacement_basis(std::string str_disp_basis) const;

--- a/src/alm.h
+++ b/src/alm.h
@@ -40,7 +40,7 @@ namespace ALM_NS
         class Displace *displace;
         class Timer *timer;
 
-        void set_run_mode(std::string mode_in);
+        void set_run_mode(std::string run_mode_in);
         std::string get_run_mode() const;
         void set_verbosity(int verbosity_in);
         int get_verbosity() const;
@@ -129,7 +129,7 @@ namespace ALM_NS
     private:
         class System *system;
 
-        std::string mode;
+        std::string run_mode;
         int verbosity;
 
         bool structure_initialized;

--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -685,8 +685,8 @@ void Constraint::generate_symmetry_constraint_in_cartesian(const int nat,
     bool has_constraint_from_symm = false;
     std::vector<std::vector<double>> const_tmp;
 
-    for (int isym = 0; isym < symmetry->nsym; ++isym) {
-        if (!symmetry->SymmData[isym].compatible_with_cartesian) {
+    for (int isym = 0; isym < symmetry->get_nsym(); ++isym) {
+        if (!symmetry->get_SymmData()[isym].compatible_with_cartesian) {
             has_constraint_from_symm = true;
             break;
         }
@@ -787,7 +787,7 @@ void Constraint::get_constraint_translation(const Cell &supercell,
     int **xyzcomponent;
 
     int ixyz, nxyz;
-    int natmin = symmetry->nat_prim;
+    int natmin = symmetry->get_nat_prim();
     int nat = supercell.number_of_atoms;
 
     unsigned int isize;
@@ -844,7 +844,7 @@ void Constraint::get_constraint_translation(const Cell &supercell,
 
     for (i = 0; i < natmin; ++i) {
 
-        iat = symmetry->map_p2s[i][0];
+        iat = symmetry->get_map_p2s()[i][0];
 
         // Generate atom pairs for each order
 
@@ -1073,7 +1073,7 @@ void Constraint::generate_rotational_constraint(const System *system,
     int icrd, jcrd;
     int order;
     int maxorder = interaction->get_maxorder();
-    int natmin = symmetry->nat_prim;
+    int natmin = symmetry->get_nat_prim();
     int mu, nu;
     int ixyz, nxyz, nxyz2;
     int mu_lambda, lambda;
@@ -1169,7 +1169,7 @@ void Constraint::generate_rotational_constraint(const System *system,
 
         for (i = 0; i < natmin; ++i) {
 
-            iat = symmetry->map_p2s[i][0];
+            iat = symmetry->get_map_p2s()[i][0];
 
             interaction_atom[0] = iat;
 
@@ -1742,7 +1742,7 @@ void Constraint::fix_forceconstants_to_file(const int order,
         get_value_from_xml(pt, "Data.Symmetry.NumberOfTranslations"));
     int natmin_ref = nat_ref / ntran_ref;
 
-    if (natmin_ref != symmetry->nat_prim) {
+    if (natmin_ref != symmetry->get_nat_prim()) {
         exit("fix_forceconstants_to_file",
              "The number of atoms in the primitive cell is not consistent.");
     }

--- a/src/fcs.cpp
+++ b/src/fcs.cpp
@@ -148,7 +148,7 @@ void Fcs::generate_force_constant_table(const int order,
 
     int **xyzcomponent;
 
-    int nsym = symm_in->SymmData.size();
+    int nsym = symm_in->get_SymmData().size();
     bool is_zero;
     bool *is_searched;
     int **map_sym;
@@ -199,8 +199,8 @@ void Fcs::generate_force_constant_table(const int order,
             if (!is_ascending(order + 2, ind)) continue;
 
             i_prim = get_minimum_index_in_primitive(order + 2, ind, nat,
-                                                    symm_in->nat_prim,
-                                                    symm_in->map_p2s);
+                                                    symm_in->get_nat_prim(),
+                                                    symm_in->get_map_p2s());
             std::swap(ind[0], ind[i_prim]);
             sort_tail(order + 2, ind);
 
@@ -218,8 +218,8 @@ void Fcs::generate_force_constant_table(const int order,
 
                 if (!is_inprim(order + 2,
                                atmn_mapped,
-                               symm_in->nat_prim,
-                               symm_in->map_p2s))
+                               symm_in->get_nat_prim(),
+                               symm_in->get_map_p2s()))
                     continue;
 
                 for (i2 = 0; i2 < nxyz; ++i2) {
@@ -236,8 +236,8 @@ void Fcs::generate_force_constant_table(const int order,
                         i_prim = get_minimum_index_in_primitive(order + 2,
                                                                 ind_mapped,
                                                                 nat,
-                                                                symm_in->nat_prim,
-                                                                symm_in->map_p2s);
+                                                                symm_in->get_nat_prim(),
+                                                                symm_in->get_map_p2s());
                         std::swap(ind_mapped[0], ind_mapped[i_prim]);
                         sort_tail(order + 2, ind_mapped);
 
@@ -269,8 +269,8 @@ void Fcs::generate_force_constant_table(const int order,
                             is_searched[ind_mapped[0]] = true;
                             for (i = 1; i < order + 2; ++i) {
                                 if ((!is_searched[ind_mapped[i]]) && is_inprim(ind_mapped[i],
-                                                                               symm_in->nat_prim,
-                                                                               symm_in->map_p2s)) {
+                                                                               symm_in->get_nat_prim(),
+                                                                               symm_in->get_map_p2s())) {
 
                                     for (j = 0; j < order + 2; ++j) ind_mapped_tmp[j] = ind_mapped[j];
                                     std::swap(ind_mapped_tmp[0], ind_mapped_tmp[i]);
@@ -365,8 +365,8 @@ void Fcs::get_constraint_symmetry(const int nat,
 
     if (order < 0) return;
 
-    int nsym = symmetry->SymmData.size();
-    int natmin = symmetry->nat_prim;
+    int nsym = symmetry->get_SymmData().size();
+    int natmin = symmetry->get_nat_prim();
     int nfcs = fc_table.size();
     bool use_compatible = false;
 
@@ -442,7 +442,7 @@ void Fcs::get_constraint_symmetry(const int nat,
 
                 for (i = 0; i < order + 2; ++i)
                     atm_index_symm[i] = map_sym[atm_index[i]][isym];
-                if (!is_inprim(order + 2, atm_index_symm, natmin, symmetry->map_p2s)) continue;
+                if (!is_inprim(order + 2, atm_index_symm, natmin, symmetry->get_map_p2s())) continue;
 
                 for (i = 0; i < nparams; ++i) const_now_omp[i] = 0.0;
 
@@ -452,7 +452,7 @@ void Fcs::get_constraint_symmetry(const int nat,
                     for (i = 0; i < order + 2; ++i)
                         ind[i] = 3 * atm_index_symm[i] + xyzcomponent[ixyz][i];
 
-                    i_prim = get_minimum_index_in_primitive(order + 2, ind, nat, natmin, symmetry->map_p2s);
+                    i_prim = get_minimum_index_in_primitive(order + 2, ind, nat, natmin, symmetry->get_map_p2s());
                     std::swap(ind[0], ind[i_prim]);
                     sort_tail(order + 2, ind);
 
@@ -553,7 +553,7 @@ void Fcs::get_available_symmop(const unsigned int nat,
 
     if (basis == "Cartesian") {
 
-        for (auto it = symmetry->SymmData.begin(); it != symmetry->SymmData.end(); ++it) {
+        for (auto it = symmetry->get_SymmData().begin(); it != symmetry->get_SymmData().end(); ++it) {
 
             if ((*it).compatible_with_cartesian == use_compatible) {
 
@@ -563,7 +563,7 @@ void Fcs::get_available_symmop(const unsigned int nat,
                     }
                 }
                 for (i = 0; i < nat; ++i) {
-                    mapping_symm[i][nsym_avail] = symmetry->map_sym[i][counter];
+                    mapping_symm[i][nsym_avail] = symmetry->get_map_sym()[i][counter];
                 }
                 ++nsym_avail;
             }
@@ -572,7 +572,7 @@ void Fcs::get_available_symmop(const unsigned int nat,
 
     } else if (basis == "Lattice") {
 
-        for (auto it = symmetry->SymmData.begin(); it != symmetry->SymmData.end(); ++it) {
+        for (auto it = symmetry->get_SymmData().begin(); it != symmetry->get_SymmData().end(); ++it) {
             if ((*it).compatible_with_lattice == use_compatible) {
                 for (i = 0; i < 3; ++i) {
                     for (j = 0; j < 3; ++j) {
@@ -581,7 +581,7 @@ void Fcs::get_available_symmop(const unsigned int nat,
                     }
                 }
                 for (i = 0; i < nat; ++i) {
-                    mapping_symm[i][nsym_avail] = symmetry->map_sym[i][counter];
+                    mapping_symm[i][nsym_avail] = symmetry->get_map_sym()[i][counter];
                 }
                 ++nsym_avail;
             }
@@ -623,7 +623,7 @@ int Fcs::get_minimum_index_in_primitive(const int n,
                                         const int *arr,
                                         const int nat,
                                         const int natmin,
-                                        int **map_p2s) const
+                                        const std::vector<std::vector<int>> &map_p2s) const
 {
     int i, j, atmnum;
 
@@ -656,7 +656,7 @@ int Fcs::get_minimum_index_in_primitive(const int n,
 bool Fcs::is_inprim(const int n,
                     const int *arr,
                     const int natmin,
-                    int **map_p2s) const
+                    const std::vector<std::vector<int>> &map_p2s) const
 {
     for (int i = 0; i < n; ++i) {
         for (int j = 0; j < natmin; ++j) {
@@ -668,7 +668,7 @@ bool Fcs::is_inprim(const int n,
 
 bool Fcs::is_inprim(const int n,
                     const int natmin,
-                    int **map_p2s) const
+                    const std::vector<std::vector<int>> &map_p2s) const
 {
     int atmn = n / 3;
 

--- a/src/fcs.h
+++ b/src/fcs.h
@@ -92,16 +92,6 @@ namespace ALM_NS
 
         void get_xyzcomponent(int, int **) const;
 
-        bool is_inprim(const int,
-                       const int *,
-                       const int,
-                       int **) const;
-
-        int get_minimum_index_in_primitive(const int,
-                                           const int *,
-                                           const int,
-                                           const int,
-                                           int **) const;
         double coef_sym(const int,
                         const double * const *,
                         const int *,
@@ -134,8 +124,12 @@ namespace ALM_NS
         void deallocate_variables();
         bool is_ascending(int, const int *) const;
         bool is_inprim(const int,
+                       const int *,
                        const int,
-                       int **) const;
+                       const std::vector<std::vector<int>> &) const;
+        bool is_inprim(const int,
+                       const int,
+                       const std::vector<std::vector<int>> &) const;
         bool is_allzero(const std::vector<double> &,
                         double,
                         int &) const;
@@ -146,6 +140,11 @@ namespace ALM_NS
                                   int **,
                                   double ***,
                                   const bool) const;
+        int get_minimum_index_in_primitive(const int,
+                                           const int *,
+                                           const int,
+                                           const int,
+                                           const std::vector<std::vector<int>> &map_p2s) const;
     };
 }
 

--- a/src/fitting.cpp
+++ b/src/fitting.cpp
@@ -83,10 +83,10 @@ int Fitting::fitmain(const Symmetry *symmetry,
 {
     timer->start_clock("fitting");
 
-    const int natmin = symmetry->nat_prim;
+    const int natmin = symmetry->get_nat_prim();
     const int nconsts = constraint->number_of_constraints;
     const int ndata_used = nend - nstart + 1;
-    const int ntran = symmetry->ntran;
+    const int ntran = symmetry->get_ntran();
     int info_fitting;
 
     int N = 0;
@@ -339,7 +339,7 @@ int Fitting::fit_without_constraints(int N,
                                      double *param_out,
                                      const int verbosity) const
 {
-    int i, j;
+    int i;
     int nrhs = 1, nrank, INFO;
     auto rcond = -1.0;
     auto f_square = 0.0;
@@ -359,8 +359,6 @@ int Fitting::fit_without_constraints(int N,
     allocate(WORK, LWORK);
     allocate(S, LMIN);
     allocate(fsum2, LMAX);
-
-    unsigned long k = 0;
 
     for (i = 0; i < M; ++i) {
         fsum2[i] = bvec[i];
@@ -524,8 +522,7 @@ int Fitting::fit_algebraic_constraints(int N,
                                        const Constraint *constraint,
                                        const int verbosity) const
 {
-    int i, j;
-    unsigned long k;
+    int i;
     int nrhs = 1, nrank, INFO, LWORK;
     int LMIN, LMAX;
     double rcond = -1.0;
@@ -611,14 +608,13 @@ void Fitting::get_matrix_elements(const int maxorder,
     data_multiplier(u_in, u_multi, ndata_fit, symmetry);
     data_multiplier(f_in, f_multi, ndata_fit, symmetry);
 
-    const int natmin = symmetry->nat_prim;
+    const int natmin = symmetry->get_nat_prim();
     const int natmin3 = 3 * natmin;
-    const int nrows = natmin3 * ndata_fit * symmetry->ntran;
     auto ncols = 0;
 
     for (i = 0; i < maxorder; ++i) ncols += fcs->nequiv[i].size();
 
-    const long ncycle = static_cast<long>(ndata_fit) * symmetry->ntran;
+    const long ncycle = static_cast<long>(ndata_fit) * symmetry->get_ntran();
 
 #ifdef _OPENMP
 #pragma omp parallel private(irow, i, j)
@@ -641,7 +637,7 @@ void Fitting::get_matrix_elements(const int maxorder,
 
             // generate r.h.s vector B
             for (i = 0; i < natmin; ++i) {
-                iat = symmetry->map_p2s[i][0];
+                iat = symmetry->get_map_p2s()[i][0];
                 for (j = 0; j < 3; ++j) {
                     im = 3 * i + j + natmin3 * irow;
                     bvec[im] = f_multi[irow][3 * iat + j];
@@ -713,9 +709,9 @@ void Fitting::get_matrix_elements_algebraic_constraint(const int maxorder,
     data_multiplier(u_in, u_multi, ndata_fit, symmetry);
     data_multiplier(f_in, f_multi, ndata_fit, symmetry);
 
-    const int natmin = symmetry->nat_prim;
+    const int natmin = symmetry->get_nat_prim();
     const int natmin3 = 3 * natmin;
-    const int nrows = natmin3 * ndata_fit * symmetry->ntran;
+    const int nrows = natmin3 * ndata_fit * symmetry->get_ntran();
     auto ncols = 0;
     auto ncols_new = 0;
 
@@ -724,7 +720,7 @@ void Fitting::get_matrix_elements_algebraic_constraint(const int maxorder,
         ncols_new += constraint->index_bimap[i].size();
     }
 
-    const long ncycle = static_cast<long>(ndata_fit) * symmetry->ntran;
+    const long ncycle = static_cast<long>(ndata_fit) * symmetry->get_ntran();
 
     std::vector<double> bvec_orig(nrows, 0.0);
 
@@ -754,7 +750,7 @@ void Fitting::get_matrix_elements_algebraic_constraint(const int maxorder,
 
             // generate r.h.s vector B
             for (i = 0; i < natmin; ++i) {
-                iat = symmetry->map_p2s[i][0];
+                iat = symmetry->get_map_p2s()[i][0];
                 for (j = 0; j < 3; ++j) {
                     im = 3 * i + j + natmin3 * irow;
                     bvec[im] = f_multi[irow][3 * iat + j];
@@ -885,9 +881,9 @@ void Fitting::get_matrix_elements_in_sparse_form(const int maxorder,
     data_multiplier(u_in, u_multi, ndata_fit, symmetry);
     data_multiplier(f_in, f_multi, ndata_fit, symmetry);
 
-    const int natmin = symmetry->nat_prim;
+    const int natmin = symmetry->get_nat_prim();
     const int natmin3 = 3 * natmin;
-    const int nrows = natmin3 * ndata_fit * symmetry->ntran;
+    const int nrows = natmin3 * ndata_fit * symmetry->get_ntran();
     auto ncols = 0;
     auto ncols_new = 0;
 
@@ -896,7 +892,7 @@ void Fitting::get_matrix_elements_in_sparse_form(const int maxorder,
         ncols_new += constraint->index_bimap[i].size();
     }
 
-    const long ncycle = static_cast<long>(ndata_fit) * symmetry->ntran;
+    const long ncycle = static_cast<long>(ndata_fit) * symmetry->get_ntran();
 
     std::vector<double> bvec_orig(nrows, 0.0);
 
@@ -928,7 +924,7 @@ void Fitting::get_matrix_elements_in_sparse_form(const int maxorder,
 
             // generate r.h.s vector B
             for (i = 0; i < natmin; ++i) {
-                iat = symmetry->map_p2s[i][0];
+                iat = symmetry->get_map_p2s()[i][0];
                 for (j = 0; j < 3; ++j) {
                     im = 3 * i + j + natmin3 * irow;
                     sp_bvec(im) = f_multi[irow][3 * iat + j];
@@ -1108,15 +1104,15 @@ void Fitting::data_multiplier(double **data_in,
     int i, j, k;
     int n_mapped;
 
-    const int nat = symmetry->nat_prim * symmetry->ntran;
+    const int nat = symmetry->get_nat_prim() * symmetry->get_ntran();
 
     auto idata = 0;
     for (i = 0; i < ndata_used; ++i) {
         std::vector<double> data_tmp(3 * nat, 0.0);
 
-        for (int itran = 0; itran < symmetry->ntran; ++itran) {
+        for (int itran = 0; itran < symmetry->get_ntran(); ++itran) {
             for (j = 0; j < nat; ++j) {
-                n_mapped = symmetry->map_sym[j][symmetry->symnum_tran[itran]];
+                n_mapped = symmetry->get_map_sym()[j][symmetry->get_symnum_tran()[itran]];
                 for (k = 0; k < 3; ++k) {
                     data_tmp[3 * n_mapped + k] = data_in[i][3 * j + k];
                 }
@@ -1134,8 +1130,8 @@ int Fitting::inprim_index(const int n,
     const auto atmn = n / 3;
     const auto crdn = n % 3;
 
-    for (int i = 0; i < symmetry->nat_prim; ++i) {
-        if (symmetry->map_p2s[i][0] == atmn) {
+    for (int i = 0; i < symmetry->get_nat_prim(); ++i) {
+        if (symmetry->get_map_p2s()[i][0] == atmn) {
             in = 3 * i + crdn;
             break;
         }

--- a/src/input_setter.cpp
+++ b/src/input_setter.cpp
@@ -139,8 +139,8 @@ void InputSetter::set_general_vars(ALM *alm,
     alm->set_verbosity(verbosity);
     nat = nat_in;
     nkd = nkd_in;
-    alm->symmetry->printsymmetry = printsymmetry;
-    alm->symmetry->tolerance = tolerance;
+    alm->symmetry->set_print_symmetry(printsymmetry);
+    alm->symmetry->set_tolerance(tolerance);
 
     if (kdname) {
         deallocate(kdname);

--- a/src/interaction.cpp
+++ b/src/interaction.cpp
@@ -67,12 +67,12 @@ void Interaction::init(const System *system,
     if (interaction_pair) {
         deallocate(interaction_pair);
     }
-    allocate(interaction_pair, maxorder, symmetry->nat_prim);
+    allocate(interaction_pair, maxorder, symmetry->get_nat_prim());
 
     if (interaction_cluster) {
         deallocate(interaction_cluster);
     }
-    allocate(interaction_cluster, maxorder, symmetry->nat_prim);
+    allocate(interaction_cluster, maxorder, symmetry->get_nat_prim());
 
     if (cluster_list) {
         deallocate(cluster_list);
@@ -103,21 +103,17 @@ void Interaction::init(const System *system,
 
     set_interaction_by_cutoff(system->get_supercell().number_of_atoms,
                               system->get_supercell().kind,
-                              symmetry->nat_prim,
-                              symmetry->map_p2s,
-                              cutoff_radii,
-                              interaction_pair);
+                              symmetry->get_nat_prim(),
+                              symmetry->get_map_p2s());
 
-    calc_interaction_clusters(symmetry->nat_prim,
+    calc_interaction_clusters(symmetry->get_nat_prim(),
                               system->get_supercell().kind,
-                              symmetry->map_p2s,
-                              interaction_pair,
+                              symmetry->get_map_p2s(),
                               system->get_x_image(),
-                              system->get_exist_image(),
-                              interaction_cluster);
+                              system->get_exist_image());
 
-    generate_pairs(symmetry->nat_prim,
-                   symmetry->map_p2s,
+    generate_pairs(symmetry->get_nat_prim(),
+                   symmetry->get_map_p2s(),
                    cluster_list,
                    interaction_cluster);
 
@@ -141,15 +137,15 @@ void Interaction::init(const System *system,
         }
 
         print_neighborlist(system->get_supercell().number_of_atoms,
-                           symmetry->nat_prim,
-                           symmetry->map_p2s,
+                           symmetry->get_nat_prim(),
+                           symmetry->get_map_p2s(),
                            system->get_supercell().kind,
                            system->get_kdname());
     }
 
     if (verbosity > 1) {
-        print_interaction_information(symmetry->nat_prim,
-                                      symmetry->map_p2s,
+        print_interaction_information(symmetry->get_nat_prim(),
+                                      symmetry->get_map_p2s(),
                                       system->get_supercell().kind,
                                       system->get_kdname(),
                                       interaction_pair);
@@ -174,7 +170,7 @@ void Interaction::init(const System *system,
 }
 
 void Interaction::generate_pairs(const int natmin,
-                                 const int * const *map_p2s,
+                                 const std::vector<std::vector<int>> &map_p2s,
                                  std::set<IntList> *pair_out,
                                  const std::set<InteractionCluster> * const *interaction_cluster) const
 {
@@ -321,7 +317,7 @@ void Interaction::get_pairs_of_minimum_distance(const int nat,
 
 void Interaction::print_neighborlist(const int nat,
                                      const int natmin,
-                                     const int * const * map_p2s,
+                                     const std::vector<std::vector<int>> &map_p2s,
                                      const std::vector<int> &kd,
                                      const std::string *kdname) const
 {
@@ -440,7 +436,7 @@ void Interaction::print_neighborlist(const int nat,
 void Interaction::generate_interaction_information_by_cutoff(const int nat,
                                                              const int natmin,
                                                              const std::vector<int> &kd,
-                                                             const int * const *map_p2s,
+                                                             const std::vector<std::vector<int>> &map_p2s,
                                                              const double * const * rc,
                                                              std::vector<int> *interaction_list) const
 {
@@ -478,17 +474,15 @@ void Interaction::generate_interaction_information_by_cutoff(const int nat,
 void Interaction::set_interaction_by_cutoff(const unsigned int nat,
                                             const std::vector<int> &kd,
                                             const unsigned int nat_prim,
-                                            const int * const * map_p2s_in,
-                                            const double * const * const *cutoff_radii_in,
-                                            std::vector<int> **interaction_pair_out) const
+                                            const std::vector<std::vector<int>> &map_p2s)
 {
     for (int order = 0; order < maxorder; ++order) {
         generate_interaction_information_by_cutoff(nat,
                                                    nat_prim,
                                                    kd,
-                                                   map_p2s_in,
-                                                   cutoff_radii_in[order],
-                                                   interaction_pair_out[order]);
+                                                   map_p2s,
+                                                   cutoff_radii[order],
+                                                   interaction_pair[order]);
     }
 }
 
@@ -558,7 +552,7 @@ const std::set<InteractionCluster> &Interaction::get_interaction_cluster(const u
 }
 
 void Interaction::print_interaction_information(const int natmin,
-                                                const int * const *map_p2s,
+                                                const std::vector<std::vector<int>> &map_p2s,
                                                 const std::vector<int> &kd,
                                                 const std::string *kdname,
                                                 const std::vector<int> * const *interaction_list)
@@ -684,11 +678,9 @@ bool Interaction::satisfy_nbody_rule(const int nelem,
 
 void Interaction::calc_interaction_clusters(const int natmin,
                                             const std::vector<int> &kd,
-                                            const int * const *map_p2s,
-                                            const std::vector<int> * const *interaction_pair_in,
+                                            const std::vector<std::vector<int>> &map_p2s,
                                             const double * const * const *x_image,
-                                            const int *exist,
-                                            std::set<InteractionCluster> **interaction_cluster_out)
+                                            const int *exist)
 {
     //
     // Calculate the complete set of interaction clusters for all orders.
@@ -699,10 +691,10 @@ void Interaction::calc_interaction_clusters(const int natmin,
                                 natmin,
                                 kd,
                                 map_p2s,
-                                interaction_pair_in[order],
+                                interaction_pair[order],
                                 x_image,
                                 exist,
-                                interaction_cluster_out[order]);
+                                interaction_cluster[order]);
 
     }
 }
@@ -711,11 +703,11 @@ void Interaction::calc_interaction_clusters(const int natmin,
 void Interaction::set_interaction_cluster(const int order,
                                           const int natmin,
                                           const std::vector<int> &kd,
-                                          const int * const *map_p2s,
+                                          const std::vector<std::vector<int>> &map_p2s,
                                           const std::vector<int> *interaction_pair_in,
                                           const double * const * const *x_image,
                                           const int *exist,
-                                          std::set<InteractionCluster> *interaction_cluster_out) const
+                                          std::set<InteractionCluster> *interaction_cluster_out)
 {
     //
     // Calculate a set of interaction clusters for the given order

--- a/src/interaction.h
+++ b/src/interaction.h
@@ -200,19 +200,6 @@ namespace ALM_NS
                          const int,
                          const std::vector<int> &) const;
 
-        void generate_interaction_information_by_cutoff(const int,
-                                                        const int,
-                                                        const std::vector<int> &,
-                                                        const int * const *,
-                                                        const double * const *,
-                                                        std::vector<int> *) const;
-
-        void set_interaction_by_cutoff(const unsigned int,
-                                       const std::vector<int> &,
-                                       const unsigned int,
-                                       const int * const *,
-                                       const double * const * const *,
-                                       std::vector<int> **) const;
         void define(const int,
                     const unsigned int,
                     const int *,
@@ -249,14 +236,26 @@ namespace ALM_NS
                                            const double * const * const *,
                                            const int *);
 
+        void generate_interaction_information_by_cutoff(const int,
+                                                        const int,
+                                                        const std::vector<int> &,
+                                                        const std::vector<std::vector<int>> &,
+                                                        const double * const *,
+                                                        std::vector<int> *) const;
+
+        void set_interaction_by_cutoff(const unsigned int,
+                                       const std::vector<int> &,
+                                       const unsigned int,
+                                       const std::vector<std::vector<int>> &);
+
         void print_neighborlist(const int,
                                 const int,
-                                const int * const *,
+                                const std::vector<std::vector<int>> &,
                                 const std::vector<int> &,
                                 const std::string *) const;
 
         void print_interaction_information(const int,
-                                           const int * const *,
+                                           const std::vector<std::vector<int>> &,
                                            const std::vector<int> &,
                                            const std::string *,
                                            const std::vector<int> * const *);
@@ -267,20 +266,18 @@ namespace ALM_NS
 
         void calc_interaction_clusters(const int,
                                        const std::vector<int> &,
-                                       const int * const *,
-                                       const std::vector<int> * const *,
+                                       const std::vector<std::vector<int>> &,
                                        const double * const *const *,
-                                       const int *,
-                                       std::set<InteractionCluster> **);
+                                       const int *);
 
         void set_interaction_cluster(const int,
                                      const int,
                                      const std::vector<int> &,
-                                     const int * const *,
+                                     const std::vector<std::vector<int>> &,
                                      const std::vector<int> *,
                                      const double * const * const*,
                                      const int *,
-                                     std::set<InteractionCluster> *) const;
+                                     std::set<InteractionCluster> *);
 
         void cell_combination(const std::vector<std::vector<int>> &,
                               const int,
@@ -288,7 +285,7 @@ namespace ALM_NS
                               std::vector<std::vector<int>> &) const;
 
         void generate_pairs(const int,
-                            const int * const *,
+                            const std::vector<std::vector<int>> &,
                             std::set<IntList> *,
                             const std::set<InteractionCluster> * const *) const;
     };

--- a/src/lasso.cpp
+++ b/src/lasso.cpp
@@ -73,14 +73,14 @@ void Lasso::lasso_main(const Symmetry *symmetry,
 {
     int i, j, k;
 
-    const auto natmin = symmetry->nat_prim;
+    const auto natmin = symmetry->get_nat_prim();
     const int maxorder = interaction->get_maxorder();
     const int ndata = fitting->ndata;
     const int nstart = fitting->nstart;
     const int nend = fitting->nend;
     const int skip_s = fitting->skip_s;
     const int skip_e = fitting->skip_e;
-    const int ntran = symmetry->ntran;
+    const int ntran = symmetry->get_ntran();
     const int ndata_used = nend - nstart + 1 - skip_e + skip_s;
 
     double scale_factor;
@@ -637,8 +637,6 @@ void Lasso::lasso_main(const Symmetry *symmetry,
         std::cout << "                 with features selected by LASSO." << std::endl;
 
         std::vector<int> nonzero_index, zero_index;
-        int iparam = 0;
-        int inew;
         for (i = 0; i < N_new; ++i) {
             if (std::abs(param[i]) >= eps) {
                 nonzero_index.push_back(i);

--- a/src/patterndisp.cpp
+++ b/src/patterndisp.cpp
@@ -70,8 +70,8 @@ void Displace::gen_displacement_pattern(const Interaction *interaction,
     // Decide preferred basis (Cartesian or Lattice)
     int ncompat_cart = 0;
     int ncompat_latt = 0;
-    for (auto it = symmetry->SymmData.begin();
-         it != symmetry->SymmData.end(); ++it) {
+    for (auto it = symmetry->get_SymmData().begin();
+         it != symmetry->get_SymmData().end(); ++it) {
         if ((*it).compatible_with_cartesian) ++ncompat_cart;
         if ((*it).compatible_with_lattice) ++ncompat_latt;
     }
@@ -398,7 +398,7 @@ void Displace::find_unique_sign_pairs(const int N,
     // Find symmetry operations which can be used to
     // reduce the number of sign patterns (+, -) of displacements
 
-    for (isym = 0; isym < symmetry->nsym; ++isym) {
+    for (isym = 0; isym < symmetry->get_nsym(); ++isym) {
 
         flag_avail = true;
         pair_tmp.clear();
@@ -406,7 +406,7 @@ void Displace::find_unique_sign_pairs(const int N,
         for (i = 0; i < N; ++i) {
             if (!flag_avail) break;
 
-            mapped_atom = symmetry->map_sym[pair_in[i] / 3][isym];
+            mapped_atom = symmetry->get_map_sym()[pair_in[i] / 3][isym];
             mapped_index = 3 * mapped_atom + pair_in[i] % 3;
 
             loc = std::find(pair_in.begin(), pair_in.end(), mapped_index);
@@ -428,7 +428,7 @@ void Displace::find_unique_sign_pairs(const int N,
             pair_tmp.clear();
 
             for (i = 0; i < list_disp_atom.size(); ++i) {
-                mapped_atom = symmetry->map_sym[list_disp_atom[i]][isym];
+                mapped_atom = symmetry->get_map_sym()[list_disp_atom[i]][isym];
 
                 for (j = 0; j < 3; ++j) {
                     disp_sym[mapped_atom][j] = 0.0;
@@ -436,12 +436,12 @@ void Displace::find_unique_sign_pairs(const int N,
                     if (preferred_basis == "Cartesian") {
                         for (k = 0; k < 3; ++k) {
                             disp_sym[mapped_atom][j]
-                                += symmetry->SymmData[isym].rotation_cart[j][k] * disp[list_disp_atom[i]][k];
+                                += symmetry->get_SymmData()[isym].rotation_cart[j][k] * disp[list_disp_atom[i]][k];
                         }
                     } else if (preferred_basis == "Lattice") {
                         for (k = 0; k < 3; ++k) {
                             disp_sym[mapped_atom][j]
-                                += static_cast<double>(symmetry->SymmData[isym].rotation[j][k])
+                                += static_cast<double>(symmetry->get_SymmData()[isym].rotation[j][k])
                                 * disp[list_disp_atom[i]][k];
                         }
                     } else {
@@ -492,20 +492,20 @@ void Displace::find_unique_sign_pairs(const int N,
             index_for_sort.clear();
 
             for (i = 0; i < list_disp_atom.size(); ++i) {
-                mapped_atom = symmetry->map_sym[list_disp_atom[i]][symnum_vec[isym]];
+                mapped_atom = symmetry->get_map_sym()[list_disp_atom[i]][symnum_vec[isym]];
 
                 for (j = 0; j < 3; ++j) {
                     disp_sym[mapped_atom][j] = 0.0;
                     if (preferred_basis == "Cartesian") {
                         for (k = 0; k < 3; ++k) {
                             disp_sym[mapped_atom][j]
-                                += symmetry->SymmData[symnum_vec[isym]].rotation_cart[j][k]
+                                += symmetry->get_SymmData()[symnum_vec[isym]].rotation_cart[j][k]
                                 * disp[list_disp_atom[i]][k];
                         }
                     } else if (preferred_basis == "Lattice") {
                         for (k = 0; k < 3; ++k) {
                             disp_sym[mapped_atom][j]
-                                += static_cast<double>(symmetry->SymmData[symnum_vec[isym]].rotation[j][k])
+                                += static_cast<double>(symmetry->get_SymmData()[symnum_vec[isym]].rotation[j][k])
                                 * disp[list_disp_atom[i]][k];
                         }
                     } else {

--- a/src/symmetry.h
+++ b/src/symmetry.h
@@ -118,18 +118,17 @@ namespace ALM_NS
         const std::vector<Maps> &get_map_s2p() const;
         const std::vector<std::vector<int>> &get_map_p2s() const;
         const std::vector<SymmetryOperation> &get_SymmData() const;
-        int ** get_map_sym() const;
+        const std::vector<std::vector<int>> &get_map_sym() const;
         const std::vector<int> &get_symnum_tran() const;
         unsigned int get_nsym() const;
-        void set_nsym(const unsigned int);
         unsigned int get_ntran() const;
         unsigned int get_nat_prim() const;
 
     private:
         unsigned int nsym, ntran, nat_prim;
-        int **map_sym;
+        std::vector<std::vector<int>> map_sym; // [nat, nsym]
         std::vector<std::vector<int>> map_p2s;  // [nat_prim, ntran]
-        std::vector<Maps> map_s2p;  // [supercell.size()]
+        std::vector<Maps> map_s2p;  // [nat]
         std::vector<SymmetryOperation> SymmData;  // [nsym]
         std::vector<int> symnum_tran;  // [ntran]
 
@@ -146,24 +145,17 @@ namespace ALM_NS
                                       const int);
 
         void gen_mapping_information(const Cell &,
-                                     const std::vector<std::vector<unsigned int>> &,
-                                     const std::vector<SymmetryOperation> &,
-                                     const std::vector<int> &);
+                                     const std::vector<std::vector<unsigned int>> &);
 
         void findsym_alm(const Cell &,
                          const int [3],
                          const std::vector<std::vector<unsigned int>> &,
-                         const Spin &,
-                         std::vector<SymmetryOperation> &);
+                         const Spin &);
 
-
-        void findsym_spglib(const Cell &,
-                            const std::vector<std::vector<unsigned int>> &,
-                            const Spin &,
-                            double,
-                            std::vector<SymmetryOperation> &,
-                            int &,
-                            std::string &);
+        int findsym_spglib(const Cell &,
+                           const std::vector<std::vector<unsigned int>> &,
+                           const Spin &,
+                           std::string &);
 
         bool is_translation(const int [3][3]) const;
         bool is_proper(const double [3][3]) const;
@@ -186,8 +178,7 @@ namespace ALM_NS
                                    const std::vector<std::vector<unsigned int>> &,
                                    const int [3],
                                    const Spin &,
-                                   const std::vector<RotationMatrix> &,
-                                   std::vector<SymmetryOperation> &);
+                                   const std::vector<RotationMatrix> &);
 
         void set_primitive_lattice(const double [3][3],
                                    int,

--- a/src/symmetry.h
+++ b/src/symmetry.h
@@ -94,6 +94,13 @@ namespace ALM_NS
         }
     };
 
+    class Maps
+    {
+    public:
+        int atom_num;
+        int tran_num;
+    };
+
     class Symmetry
     {
     public:
@@ -104,47 +111,44 @@ namespace ALM_NS
                   const int verbosity,
                   Timer *timer);
 
+        double get_tolerance() const;
+        void set_tolerance(const double);
+        int get_print_symmetry() const;
+        void set_print_symmetry(const int);
+        const std::vector<Maps> &get_map_s2p() const;
+        const std::vector<std::vector<int>> &get_map_p2s() const;
+        const std::vector<SymmetryOperation> &get_SymmData() const;
+        int ** get_map_sym() const;
+        const std::vector<int> &get_symnum_tran() const;
+        unsigned int get_nsym() const;
+        void set_nsym(const unsigned int);
+        unsigned int get_ntran() const;
+        unsigned int get_nat_prim() const;
+
+    private:
         unsigned int nsym, ntran, nat_prim;
-        std::vector<int> symnum_tran;
+        int **map_sym;
+        std::vector<std::vector<int>> map_p2s;  // [nat_prim, ntran]
+        std::vector<Maps> map_s2p;  // [supercell.size()]
+        std::vector<SymmetryOperation> SymmData;  // [nsym]
+        std::vector<int> symnum_tran;  // [ntran]
 
         double tolerance;
         bool use_internal_symm_finder;
         int printsymmetry;
 
-        int **map_sym;
-        int **map_p2s;
-
-        class Maps
-        {
-        public:
-            int atom_num;
-            int tran_num;
-        };
-
-        std::vector<Maps> map_s2p;
-        std::vector<SymmetryOperation> SymmData;
-
-    private:
         void set_default_variables();
         void deallocate_variables();
         void setup_symmetry_operation(const Cell &,
                                       const int [3],
                                       const std::vector<std::vector<unsigned int>> &,
                                       const Spin &,
-                                      const int,
-                                      std::vector<SymmetryOperation> &,
-                                      unsigned int &,
-                                      unsigned int &,
-                                      unsigned int &,
-                                      std::vector<int> &);
+                                      const int);
 
         void gen_mapping_information(const Cell &,
                                      const std::vector<std::vector<unsigned int>> &,
                                      const std::vector<SymmetryOperation> &,
-                                     const std::vector<int> &,
-                                     int **,
-                                     int **,
-                                     std::vector<Maps> &) const;
+                                     const std::vector<int> &);
 
         void findsym_alm(const Cell &,
                          const int [3],

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -52,8 +52,8 @@ void Writer::write_input_vars(const ALM *alm) const
     std::cout << "  PREFIX = " << alm->files->job_title << std::endl;
     std::cout << "  MODE = " << alm->get_run_mode() << std::endl;
     std::cout << "  NAT = " << nat << "; NKD = " << nkd << std::endl;
-    std::cout << "  PRINTSYM = " << alm->symmetry->printsymmetry
-        << "; TOLERANCE = " << alm->symmetry->tolerance << std::endl;
+    std::cout << "  PRINTSYM = " << alm->symmetry->get_print_symmetry()
+              << "; TOLERANCE = " << alm->symmetry->get_tolerance() << std::endl;
     std::cout << "  KD = ";
     for (i = 0; i < nkd; ++i) std::cout << std::setw(4) << alm->get_kdname()[i];
     std::cout << std::endl;
@@ -205,7 +205,7 @@ void Writer::write_force_constants(ALM *alm) const
                 for (l = 1; l < order + 2; ++l) {
                     atom_tmp.push_back(alm->fcs->fc_table[order][m].elems[l] / 3);
                 }
-                j = alm->symmetry->map_s2p[alm->fcs->fc_table[order][m].elems[0] / 3].atom_num;
+                j = alm->symmetry->get_map_s2p()[alm->fcs->fc_table[order][m].elems[0] / 3].atom_num;
                 std::sort(atom_tmp.begin(), atom_tmp.end());
 
                 iter_cluster = alm->interaction->get_interaction_cluster(order, j).find(
@@ -389,8 +389,8 @@ void Writer::write_misc_xml(ALM *alm)
     }
 
     system_structure.nat = alm->get_supercell().number_of_atoms;
-    system_structure.natmin = alm->symmetry->nat_prim;
-    system_structure.ntran = alm->symmetry->ntran;
+    system_structure.natmin = alm->symmetry->get_nat_prim();
+    system_structure.ntran = alm->symmetry->get_ntran();
     system_structure.nspecies = alm->get_supercell().number_of_elems;
 
     AtomProperty prop_tmp;
@@ -400,8 +400,8 @@ void Writer::write_misc_xml(ALM *alm)
         prop_tmp.y = alm->get_supercell().x_fractional[i][1];
         prop_tmp.z = alm->get_supercell().x_fractional[i][2];
         prop_tmp.kind = alm->get_supercell().kind[i];
-        prop_tmp.atom = alm->symmetry->map_s2p[i].atom_num + 1;
-        prop_tmp.tran = alm->symmetry->map_s2p[i].tran_num + 1;
+        prop_tmp.atom = alm->symmetry->get_map_s2p()[i].atom_num + 1;
+        prop_tmp.tran = alm->symmetry->get_map_s2p()[i].tran_num + 1;
 
         system_structure.atoms.emplace_back(AtomProperty(prop_tmp));
     }
@@ -453,11 +453,11 @@ void Writer::write_misc_xml(ALM *alm)
         child.put("<xmlattr>.element", alm->get_kdname()[alm->get_supercell().kind[i] - 1]);
     }
 
-    pt.put("Data.Symmetry.NumberOfTranslations", alm->symmetry->ntran);
+    pt.put("Data.Symmetry.NumberOfTranslations", alm->symmetry->get_ntran());
     for (i = 0; i < system_structure.ntran; ++i) {
         for (j = 0; j < system_structure.natmin; ++j) {
             ptree &child = pt.add("Data.Symmetry.Translations.map",
-                                  alm->symmetry->map_p2s[j][i] + 1);
+                                  alm->symmetry->get_map_p2s()[j][i] + 1);
             child.put("<xmlattr>.tran", i + 1);
             child.put("<xmlattr>.atom", j + 1);
         }
@@ -497,7 +497,7 @@ void Writer::write_misc_xml(ALM *alm)
         for (i = 0; i < 2; ++i) {
             pair_tmp[i] = alm->fcs->fc_table[0][ihead].elems[i] / 3;
         }
-        j = alm->symmetry->map_s2p[pair_tmp[0]].atom_num;
+        j = alm->symmetry->get_map_s2p()[pair_tmp[0]].atom_num;
 
         atom_tmp.clear();
         atom_tmp.push_back(pair_tmp[1]);
@@ -531,7 +531,7 @@ void Writer::write_misc_xml(ALM *alm)
             for (i = 0; i < 3; ++i) {
                 pair_tmp[i] = alm->fcs->fc_table[1][ihead].elems[i] / 3;
             }
-            j = alm->symmetry->map_s2p[pair_tmp[0]].atom_num;
+            j = alm->symmetry->get_map_s2p()[pair_tmp[0]].atom_num;
 
             atom_tmp.clear();
             for (i = 1; i < 3; ++i) {
@@ -574,7 +574,7 @@ void Writer::write_misc_xml(ALM *alm)
             pair_tmp[k] = fctmp.elems[k] / 3;
         }
 
-        j = alm->symmetry->map_s2p[pair_tmp[0]].atom_num;
+        j = alm->symmetry->get_map_s2p()[pair_tmp[0]].atom_num;
 
         atom_tmp.clear();
         atom_tmp.push_back(pair_tmp[1]);
@@ -624,7 +624,7 @@ void Writer::write_misc_xml(ALM *alm)
             for (k = 0; k < order + 2; ++k) {
                 pair_tmp[k] = fctmp.elems[k] / 3;
             }
-            j = alm->symmetry->map_s2p[pair_tmp[0]].atom_num;
+            j = alm->symmetry->get_map_s2p()[pair_tmp[0]].atom_num;
 
             atom_tmp.clear();
 
@@ -713,9 +713,9 @@ void Writer::write_hessian(ALM *alm) const
         ip = fctmp.mother;
 
         for (i = 0; i < 2; ++i) pair_tmp[i] = fctmp.elems[i] / 3;
-        for (itran = 0; itran < alm->symmetry->ntran; ++itran) {
+        for (itran = 0; itran < alm->symmetry->get_ntran(); ++itran) {
             for (i = 0; i < 2; ++i) {
-                pair_tran[i] = alm->symmetry->map_sym[pair_tmp[i]][alm->symmetry->symnum_tran[itran]];
+                pair_tran[i] = alm->symmetry->get_map_sym()[pair_tmp[i]][alm->symmetry->get_symnum_tran()[itran]];
             }
             hessian[3 * pair_tran[0] + fctmp.elems[0] % 3][3 * pair_tran[1] + fctmp.elems[1] % 3]
                 = alm->fitting->params[ip] * fctmp.sign;
@@ -778,9 +778,9 @@ void Writer::write_in_QEformat(ALM *alm) const
         ip = fctmp.mother;
 
         for (i = 0; i < 2; ++i) pair_tmp[i] = fctmp.elems[i] / 3;
-        for (itran = 0; itran < alm->symmetry->ntran; ++itran) {
+        for (itran = 0; itran < alm->symmetry->get_ntran(); ++itran) {
             for (i = 0; i < 2; ++i) {
-                pair_tran[i] = alm->symmetry->map_sym[pair_tmp[i]][alm->symmetry->symnum_tran[itran]];
+                pair_tran[i] = alm->symmetry->get_map_sym()[pair_tmp[i]][alm->symmetry->get_symnum_tran()[itran]];
             }
             hessian[3 * pair_tran[0] + fctmp.elems[0] % 3][3 * pair_tran[1] + fctmp.elems[1] % 3]
                 = alm->fitting->params[ip] * fctmp.sign;
@@ -822,9 +822,9 @@ void Writer::write_fc3_thirdorderpy_format(ALM *alm) const
     int ***has_element;
     int nelems = 0;
     int nat3 = 3 * alm->get_supercell().number_of_atoms;
-    int natmin = alm->symmetry->nat_prim;
+    int natmin = alm->symmetry->get_nat_prim();
     int nat = alm->get_supercell().number_of_atoms;
-    int ntran = alm->symmetry->ntran;
+    int ntran = alm->symmetry->get_ntran();
 
     std::vector<int> atom_tmp;
     std::vector<std::vector<int>> cell_dummy;
@@ -865,7 +865,7 @@ void Writer::write_fc3_thirdorderpy_format(ALM *alm) const
             coord_tmp[i] = fctmp.elems[i] % 3;
         }
 
-        j = alm->symmetry->map_s2p[pair_tmp[0]].atom_num;
+        j = alm->symmetry->get_map_s2p()[pair_tmp[0]].atom_num;
 
         if (pair_tmp[1] > pair_tmp[2]) {
             atom_tmp[0] = pair_tmp[2];
@@ -914,8 +914,8 @@ void Writer::write_fc3_thirdorderpy_format(ALM *alm) const
                 for (ktran = 0; ktran < ntran; ++ktran) {
                     for (k = 0; k < natmin; ++k) {
 
-                        jat = alm->symmetry->map_p2s[j][jtran];
-                        kat = alm->symmetry->map_p2s[k][ktran];
+                        jat = alm->symmetry->get_map_p2s()[j][jtran];
+                        kat = alm->symmetry->get_map_p2s()[k][ktran];
 
                         if (!has_element[i][jat][kat]) continue;
 
@@ -937,8 +937,8 @@ void Writer::write_fc3_thirdorderpy_format(ALM *alm) const
 
                         multiplicity = (*iter_cluster).cell.size();
 
-                        jat0 = alm->symmetry->map_p2s[alm->symmetry->map_s2p[atom_tmp[0]].atom_num][0];
-                        kat0 = alm->symmetry->map_p2s[alm->symmetry->map_s2p[atom_tmp[1]].atom_num][0];
+                        jat0 = alm->symmetry->get_map_p2s()[alm->symmetry->get_map_s2p()[atom_tmp[0]].atom_num][0];
+                        kat0 = alm->symmetry->get_map_p2s()[alm->symmetry->get_map_s2p()[atom_tmp[1]].atom_num][0];
 
                         for (auto imult = 0; imult < multiplicity; ++imult) {
                             std::vector<int> cell_now = (*iter_cluster).cell[imult];


### PR DESCRIPTION
Public variables in Symmetry class were moved to private. Along this, required setters and getters were written. `int **map_p2s` was changed to `std::vector<std::vector<int>> map_p2s`, by which in the future, passing accompanying array sizes like `nat_prim` or `ntrans` can be avoided and the code will be a bit readable, hopefully. `int **map_sym` was done the same as `map_p2s` for `nsym`.
