### PR TITLE
Update of build settings and its documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+matrix:
+  include:
+  - python: '2.7'
+    sudo: false
+    env: TRAVIS_PYTHON_VERSION='2.7'
+  - python: '3.6'
+    sudo: false
+    env: TRAVIS_PYTHON_VERSION='3.6'
+
+before_install:
+- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+- bash miniconda.sh -b -p $HOME/miniconda;
+- export PATH="$HOME/miniconda/bin:$PATH";
+- conda create -n travis python="$TRAVIS_PYTHON_VERSION"
+- source activate travis
+
+install:
+- conda install --no-update-deps --yes python="$TRAVIS_PYTHON_VERSION" gcc_linux-64 gxx_linux-64 cmake boost eigen numpy ipython
+- conda install --no-update-deps --yes python="$TRAVIS_PYTHON_VERSION" -c conda-forge openblas h5py
+- pwd
+
+script:
+- pwd

--- a/CMakeLists.txt.conda
+++ b/CMakeLists.txt.conda
@@ -1,0 +1,122 @@
+cmake_minimum_required(VERSION 3.1)
+set(CMAKE_MACOSX_RPATH 1)
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -fopenmp")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -O2")
+#set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_BUILD_TYPE RELEASE)
+
+project(alm)
+# set(CMAKE_CXX_COMPILER "clang++")
+option(WITH_SPARSE_SOLVER "Use sparse solver option" ON)
+
+if(WIN32)
+  LINK_DIRECTORIES(C:\\lapack)
+  LINK_DIRECTORIES(C:\\spglib)
+  include_directories(C:\\spglib)
+  set(LAPACK_LIBRARIES lapack)
+  set(spglib symspg)
+endif()
+
+if (UNIX)
+  #set(ENV{BLA_VENDOR} "Intel10_64lp")
+  find_package(LAPACK REQUIRED)
+  #set(LAPACK_LIBRARIES "-lopenblas")
+  include_directories("$ENV{HOME}/ALM/spglib/include")
+  set(spglib "-L$ENV{HOME}/ALM/spglib/lib -lsymspg")
+endif()
+
+#
+# Add openmp flag if available
+#
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
+
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+
+if (WITH_SPARSE_SOLVER)
+    add_definitions(-DWITH_SPARSE_SOLVER)
+    find_package(Eigen3 REQUIRED)
+    include_directories(${EIGEN3_INCLUDE_DIR})
+endif()
+# Version numbers
+file(READ ${PROJECT_SOURCE_DIR}/src/version.h version_file)
+string(REGEX MATCH "ALAMODE_VERSION = \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" alm_version ${version_file})
+set(alm_version ${CMAKE_MATCH_1})
+MESSAGE("ALM version: ${CMAKE_MATCH_1}")
+set(serial "${alm_version}")
+set(soserial "1")
+
+# Source code
+include_directories("${PROJECT_SOURCE_DIR}/src")
+set(SOURCES ${PROJECT_SOURCE_DIR}/src/alm.cpp
+            ${PROJECT_SOURCE_DIR}/src/constraint.cpp
+            ${PROJECT_SOURCE_DIR}/src/fcs.cpp
+            ${PROJECT_SOURCE_DIR}/src/files.cpp
+            ${PROJECT_SOURCE_DIR}/src/input_parser.cpp
+            ${PROJECT_SOURCE_DIR}/src/input_setter.cpp
+            ${PROJECT_SOURCE_DIR}/src/interaction.cpp
+            ${PROJECT_SOURCE_DIR}/src/optimize.cpp
+            ${PROJECT_SOURCE_DIR}/src/patterndisp.cpp
+            ${PROJECT_SOURCE_DIR}/src/rref.cpp
+            ${PROJECT_SOURCE_DIR}/src/symmetry.cpp
+            ${PROJECT_SOURCE_DIR}/src/system.cpp
+            ${PROJECT_SOURCE_DIR}/src/timer.cpp
+            ${PROJECT_SOURCE_DIR}/src/writer.cpp)
+
+set(HEADERS ${PROJECT_SOURCE_DIR}/src/alm.h
+            ${PROJECT_SOURCE_DIR}/src/constraint.h
+            ${PROJECT_SOURCE_DIR}/src/fcs.h
+            ${PROJECT_SOURCE_DIR}/src/files.h
+            ${PROJECT_SOURCE_DIR}/src/input_parser.h
+            ${PROJECT_SOURCE_DIR}/src/input_setter.h
+            ${PROJECT_SOURCE_DIR}/src/interaction.h
+            ${PROJECT_SOURCE_DIR}/src/optimize.h
+            ${PROJECT_SOURCE_DIR}/src/patterndisp.h
+            ${PROJECT_SOURCE_DIR}/src/rref.h
+            ${PROJECT_SOURCE_DIR}/src/symmetry.h
+            ${PROJECT_SOURCE_DIR}/src/system.h
+            ${PROJECT_SOURCE_DIR}/src/timer.h
+            ${PROJECT_SOURCE_DIR}/src/writer.h)
+
+# # Trick to use gcc to compile *.cpp: This doesn't work because of boost
+# SET_SOURCE_FILES_PROPERTIES(${SOURCES} PROPERTIES LANGUAGE C)
+# set(CMAKE_C_COMPILER "gcc")
+
+# Executable
+add_executable(alm ${PROJECT_SOURCE_DIR}/src/main.cpp
+                   ${PROJECT_SOURCE_DIR}/src/alm_cui.cpp
+                   ${SOURCES} ${HEADERS})
+target_link_libraries(alm ${Boost_LIBRARIES} ${LAPACK_LIBRARIES} ${spglib})
+target_link_libraries(alm ${LAPACK_LIBRARIES})
+set_property(TARGET alm PROPERTY CXX_STANDARD 11)
+set_property(TARGET alm PROPERTY CXX_STANDARD_REQUIRED ON)
+
+# add_executable(alm ${PROJECT_SOURCE_DIR}/src/main.cpp)
+# target_link_libraries(alm ${almcxx_static} ${Boost_LIBRARIES} lapack)
+
+# Shared library
+add_library(almcxx SHARED ${SOURCES})
+#target_link_libraries(almcxx ${Boost_LIBRARIES} ${LAPACK_LIBRARIES})
+target_link_libraries(almcxx ${Boost_LIBRARIES} ${LAPACK_LIBRARIES} ${spglib})
+#target_link_libraries(almcxx ${LAPACK_LIBRARIES})
+set_property(TARGET almcxx PROPERTY VERSION ${serial})
+set_property(TARGET almcxx PROPERTY SOVERSION ${soserial})
+set_property(TARGET almcxx PROPERTY CXX_STANDARD 11)
+set_property(TARGET almcxx PROPERTY CXX_STANDARD_REQUIRED ON)
+#install(TARGETS almcxx LIBRARY DESTINATION ${PROJECT_SOURCE_DIR}/lib)
+install(TARGETS almcxx DESTINATION ${PROJECT_SOURCE_DIR}/lib)
+
+# Static link library
+add_library(almcxx_static STATIC ${SOURCES})
+set_property(TARGET almcxx_static PROPERTY VERSION ${serial})
+set_property(TARGET almcxx_static PROPERTY SOVERSION ${soserial})
+set_property(TARGET almcxx_static PROPERTY OUTPUT_NAME almcxx)
+set_property(TARGET almcxx_static PROPERTY CXX_STANDARD 11)
+set_property(TARGET almcxx_static PROPERTY CXX_STANDARD_REQUIRED ON)
+install(TARGETS almcxx_static ARCHIVE DESTINATION ${PROJECT_SOURCE_DIR}/lib)
+
+# Header file
+install(FILES ${PROJECT_SOURCE_DIR}/src/alm.h DESTINATION ${PROJECT_SOURCE_DIR}/include)

--- a/docs/compile-with-conda-packages.rst
+++ b/docs/compile-with-conda-packages.rst
@@ -1,0 +1,201 @@
+.. _compile_with_conda_packages:
+
+Building ALM using conda
+=========================
+
+ALM is written in C++. So to build it, a set of build tools is needed
+to install. Currently using conda gives a relatively simple and
+uniform way to perform building ALM. There are steps to achieve it as follows.
+
+.. contents::
+   :depth: 2
+   :local:
+
+Creating a conda environment
+-----------------------------
+
+At first, it is recommended `to prepare a conda environment
+<https://conda.io/docs/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands>`_,
+which is done by::
+
+   % conda create --name alm
+
+Here the name of the conda environment is chosen ``alm``. The
+detailed instruction about the conda environment is found at
+
+- https://conda.io/docs/user-guide/tasks/manage-environments.html
+
+Preparing build tools
+---------------------
+
+Compilers prepared by conda for linux and macOS are different. See:
+
+- https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html
+
+The necessary conda packages to build ALM on linux and macOS are
+respectively installed as shown below.
+
+For linux
+~~~~~~~~~~
+
+::
+
+   % conda install gcc_linux-64 gxx_linux-64 cmake boost eigen openblas numpy h5py ipython
+
+
+For macOS
+~~~~~~~~~~
+
+::
+
+   % conda install clang_osx-64 clangxx_osx-64 llvm-openmp cmake boost eigen numpy ipython
+   % conda install -c conda-forge openblas h5py
+
+Along with this installation of compilers, conda activation scripts of
+environment variables are installed under
+``$CONDA_PREFIX/etc/conda/activate.d``. On macOS Mojave, unfortunately
+this script doesn't work well at this moment (15/Oct/2018). So the
+comment out the line below in the script
+``$CONDA_PREFIX/etc/conda/activate.d/activate_clang_osx-64.sh`` is
+required::
+
+   # "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT:-$(xcrun --show-sdk-path)}"
+
+
+Preparing spglib
+----------------
+
+`spglib <https://github.com/atztogo/spglib>`_ is necessary to build to
+be linked by ALM. Spglib is built as follows::
+
+   % git clone https://github.com/atztogo/spglib.git
+   % cd spglib
+   % mkdir _build && cd _build
+   % cmake -DCMAKE_INSTALL_PREFIX="" ..
+   % make
+   % make DESTDIR=.. install
+
+Detailed build configuration can be controlled to modify
+``CMakeLists.txt`` if necessary.
+
+.. _build_ALMlib:
+
+Building ALM library and/or ALM python module
+---------------------------------------------
+
+Now the directory structure supposed in this document is shown as below::
+
+   $HOME
+   |-- ALM
+   |   |-- ALM
+   |   |   |-- include/
+   |   |   |-- lib/
+   |   |   |-- python/
+   |   |   |-- src/
+   |   |   |-- _build/
+   |   |   |-- CMakeLists.txt
+   |   |   `-- ...
+   |   `-- spglib
+   |       |-- include/
+   |       |-- lib/
+   |       |-- _build/
+   |       |-- setup.py
+   |       |-- CMakeLists.txt
+   |       `-- ...
+   |-- miniconda/envs/alm/include
+   |-- miniconda/envs/alm/include/eigen3
+   `-- ...
+
+In this directory structure, ``$CONDA_PREFIX`` is equivalent to
+``$HOME/miniconda/envs/alm``.
+
+Building ALM python module by Modifying ``setup.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ALM python module is built on the directory
+``$HOME/ALM/ALM/python``. So first you have to move to this directory.
+
+To link the spglib static link library (``libsymspg.a``),
+``spglib_dir`` in ``setup.py`` has to be modified appropriately. If we
+assume it exists in the directory ``$HOME/ALM/spglib/lib`` following
+the :ref:`above <build_ALMlib>` directory structure, the modification
+is::
+
+   spglib_dir = os.path.join(home, "ALM", "spglib", "lib")
+
+To build ALM, it is necessary to tell compiler where the libraries and
+their header files exist. If the conda environment is used, the
+library path would be set correctly. However the include paths
+probably have to be set for boost and eigen by::
+
+   % export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/include:$CONDA_PREFIX/include/eigen3:$HOME/ALM/spglib/include
+
+The build of the ALM python module is performed by a C++ compiler but
+not a C compiler. To let the python `setuptools
+<https://setuptools.readthedocs.io/en/latest/>`_ choose the C++
+compiler installed using conda, the environment variables ``CC`` is
+overwritten by ``CXX`` by
+
+::
+
+   % export CC=$CXX
+
+Finally the build and installation in the user directory is done by
+
+::
+
+   % python setup.py build
+   % pip install -e .
+
+
+
+Building ALM library for C++ by modifying ``CMakeLists.txt``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need only ALM python module, this section can be skipped.
+
+Let's assume we are in the directory ``$HOME/ALM/ALM`` (see above
+:ref:`directory structure <build_ALMlib>`). The ALM
+library for C++ is built using cmake. The cmake's configuration file
+has to have the filename ``CMakeLists.txt``. So its example of
+``CMakeLists.txt.conda`` is renamed to ``CMakeLists.txt``, i.e.,
+
+::
+
+   % mv CMakeLists.txt.conda CMakeLists.txt
+
+Then this ``CMakeLists.txt`` is to be modified appropriately.  At
+least, the following lines for spglib library setting would be
+modified depending on your location of the spglib library,
+
+::
+
+   include_directories("$ENV{HOME}/ALM/spglib/include")
+   set(spglib "-L$ENV{HOME}/ALM/spglib/lib -lsymspg")
+
+These lines are an example made along with the directory
+structure shown :ref:`above <build_ALMlib>`. Using this
+``CMakeLists.txt``, the ALM library for c++ is built by
+
+::
+
+   % mkdir _build && cd _build
+   % cmake ..
+   % make -j4
+   % make install
+
+
+The dynamic and static link libraries and the head file are installed
+at
+
+- ``$HOME/ALM/ALM/lib/libalmcxx.dylib``
+- ``$HOME/ALM/ALM/lib/libalmcxx.a``
+- ``$HOME/ALM/ALM/include/alm.h``
+
+These libraries are linked to spglib, openblas, and boost
+dynamically. Therefore to use the ALM library for C++,
+``LD_LIBRARY_PATH`` has to be set properly, e.g.,
+
+::
+
+   export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$HOME/ALM/spglib/lib:$LD_LIBRARY_PATH

--- a/docs/compile-with-conda-packages.rst
+++ b/docs/compile-with-conda-packages.rst
@@ -3,9 +3,11 @@
 Building ALM using conda
 =========================
 
-ALM is written in C++. So to build it, a set of build tools is needed
-to install. Currently using conda gives a relatively simple and
-uniform way to perform building ALM. There are steps to achieve it as follows.
+ALM is written in C++. To build it, a set of build tools is
+needed. Currently using conda gives a relatively simple and uniform
+way to perform building the ALM python module and the ALM library for
+C++. In this documentation, it is presented a step-by-step procedure
+to build them using conda.
 
 .. contents::
    :depth: 2
@@ -25,8 +27,8 @@ detailed instruction about the conda environment is found at
 
 - https://conda.io/docs/user-guide/tasks/manage-environments.html
 
-Preparing build tools
----------------------
+Preparing build tools by conda
+-------------------------------
 
 Compilers prepared by conda for linux and macOS are different. See:
 
@@ -40,8 +42,8 @@ For linux
 
 ::
 
-   % conda install gcc_linux-64 gxx_linux-64 cmake boost eigen openblas numpy h5py ipython
-
+   % conda install gcc_linux-64 gxx_linux-64 cmake boost eigen numpy ipython
+   % conda install -c conda-forge openblas h5py
 
 For macOS
 ~~~~~~~~~~
@@ -62,26 +64,10 @@ required::
    # "CONDA_BUILD_SYSROOT,${CONDA_BUILD_SYSROOT:-$(xcrun --show-sdk-path)}"
 
 
-Preparing spglib
-----------------
-
-`spglib <https://github.com/atztogo/spglib>`_ is necessary to build to
-be linked by ALM. Spglib is built as follows::
-
-   % git clone https://github.com/atztogo/spglib.git
-   % cd spglib
-   % mkdir _build && cd _build
-   % cmake -DCMAKE_INSTALL_PREFIX="" ..
-   % make
-   % make DESTDIR=.. install
-
-Detailed build configuration can be controlled to modify
-``CMakeLists.txt`` if necessary.
-
 .. _build_ALMlib:
 
-Building ALM library and/or ALM python module
----------------------------------------------
+Building ALM python module and/or ALM library for C++
+------------------------------------------------------
 
 Now the directory structure supposed in this document is shown as below::
 
@@ -90,7 +76,7 @@ Now the directory structure supposed in this document is shown as below::
    |   |-- ALM
    |   |   |-- include/
    |   |   |-- lib/
-   |   |   |-- python/
+   |   |   |-- python/setup.py
    |   |   |-- src/
    |   |   |-- _build/
    |   |   |-- CMakeLists.txt
@@ -99,7 +85,6 @@ Now the directory structure supposed in this document is shown as below::
    |       |-- include/
    |       |-- lib/
    |       |-- _build/
-   |       |-- setup.py
    |       |-- CMakeLists.txt
    |       `-- ...
    |-- miniconda/envs/alm/include
@@ -107,7 +92,34 @@ Now the directory structure supposed in this document is shown as below::
    `-- ...
 
 In this directory structure, ``$CONDA_PREFIX`` is equivalent to
-``$HOME/miniconda/envs/alm``.
+``$HOME/miniconda/envs/alm``. The location of ``miniconda`` directory
+is chosen at the installation time of miniconda.
+
+ALM and spglib are downloaded from github. ``ALM`` and ``spglib``
+directories are created running the following commands::
+
+   % git clone https://github.com/ttadano/ALM.git
+   % git clone https://github.com/atztogo/spglib.git
+
+When this is done on ``$HOME/ALM``, the above directory structure is
+made. If git command doesn't exist in your system, it is also obtained
+from conda by ``conda install git``.
+
+Preparing spglib
+~~~~~~~~~~~~~~~~
+
+`spglib <https://github.com/atztogo/spglib>`_ is necessary for to
+build both of the ALM python module and/or ALM library for C++. It is
+assumed that we are in ``$HOME/ALM/spglib``, where spglib is built as
+follows::
+
+   % mkdir _build && cd _build
+   % cmake -DCMAKE_INSTALL_PREFIX="" ..
+   % make
+   % make DESTDIR=.. install
+
+Detailed build configuration is controlled to modify
+``CMakeLists.txt`` if necessary.
 
 Building ALM python module by Modifying ``setup.py``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -146,8 +158,6 @@ Finally the build and installation in the user directory is done by
 
    % python setup.py build
    % pip install -e .
-
-
 
 Building ALM library for C++ by modifying ``CMakeLists.txt``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,7 +198,7 @@ structure shown :ref:`above <build_ALMlib>`. Using this
 The dynamic and static link libraries and the head file are installed
 at
 
-- ``$HOME/ALM/ALM/lib/libalmcxx.dylib``
+- ``$HOME/ALM/ALM/lib/libalmcxx.dylib`` or ``$HOME/ALM/ALM/lib/libalmcxx.so``
 - ``$HOME/ALM/ALM/lib/libalmcxx.a``
 - ``$HOME/ALM/ALM/include/alm.h``
 

--- a/python/_alm.c
+++ b/python/_alm.c
@@ -3,6 +3,10 @@
 #include <numpy/arrayobject.h>
 #include "alm_wrapper.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if (PY_MAJOR_VERSION < 3) && (PY_MINOR_VERSION < 6)
 #define PYUNICODE_FROMSTRING PyString_FromString
 #else
@@ -542,3 +546,7 @@ static PyObject * py_get_matrix_elements(PyObject *self, PyObject *args)
 
   Py_RETURN_NONE;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,7 @@ compile_with_sources = True
 # |   |-- ALM
 # |   |   |-- include/
 # |   |   |-- lib/
-# |   |   |-- python/
+# |   |   |-- python/setup.py
 # |   |   |-- src/
 # |   |   |-- _build/
 # |   |   |-- CMakeLists.txt
@@ -27,25 +27,27 @@ compile_with_sources = True
 # |       |-- include/
 # |       |-- lib/
 # |       |-- _build/
-# |       |-- setup.py
 # |       |-- CMakeLists.txt
 # |       `-- ...
 # |-- miniconda/envs/alm/include
 # |-- miniconda/envs/alm/include/eigen3
 # `-- ...
 
-spglib_dir = os.path.join(home, "ALM", "spglib", "lib")
+library_dirs = []
+extra_link_args = []
 include_dirs = []
+
+spglib_dir = os.path.join(home, "ALM", "spglib", "lib")
 include_dirs_numpy = [numpy.get_include()]
 include_dirs += include_dirs_numpy
+
+# The following setting can work in place of "export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/include:$CONDA_PREFIX/include/eigen3:$HOME/ALM/spglib/include".
 # include_dir_spglib = os.path.join(home, "ALM", "spglib", "include")
 # include_dirs.append(include_dir_spglib)
 # include_dir_boost = os.path.join(home, "miniconda", "envs", "alm", "include")
 # include_dirs.append(include_dir_boost)
 # include_dir_eigen = os.path.join(include_dir_boost, "eigen3")
 # include_dirs.append(include_dir_eigen)
-library_dirs = []
-extra_link_args = []
 
 if compile_with_sources:
     cpp_files = ['alm.cpp',
@@ -85,7 +87,8 @@ else:  # compile with library
 extension = Extension('alm._alm',
                       include_dirs=include_dirs,
                       library_dirs=library_dirs,
-                      extra_compile_args = ['-fopenmp', '-std=c++11'],
+                      extra_compile_args = ['-fopenmp', '-std=c++11',
+                                            '-DWITH_SPARSE_SOLVER'],
                       extra_link_args=extra_link_args,
                       sources=sources)
 


### PR DESCRIPTION
`setup.py` and `CMakeLists.txt.conda` were updated along with a documentation of how to build ALM. I hope that users can build ALM with less pain by this set of updates. The file name of `CMakeLists.txt.conda` and `compile-with-conda-packages.rst` would be changed at your convenience.

I tested this build procedure written in the documentation on macOS Mojave (clean installed) and Ubuntu 16.04.