### PR TITLE
Initial setup of Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,44 @@
-matrix:
-  include:
-  - python: '2.7'
-    sudo: false
-    env: TRAVIS_PYTHON_VERSION='2.7'
-  - python: '3.6'
-    sudo: false
-    env: TRAVIS_PYTHON_VERSION='3.6'
+language: python
+sudo: false
+dist: trusty
+
+python:
+  - '2.7'
+  - '3.6'
 
 before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-- bash miniconda.sh -b -p $HOME/miniconda;
-- export PATH="$HOME/miniconda/bin:$PATH";
-- conda create -n travis python="$TRAVIS_PYTHON_VERSION"
+- bash miniconda.sh -b -p $HOME/miniconda
+- export PATH="$HOME/miniconda/bin:$PATH"
+- echo $TRAVIS_PYTHON_VERSION
+- conda create --yes -n travis python="$TRAVIS_PYTHON_VERSION"
 - source activate travis
 
 install:
-- conda install --no-update-deps --yes python="$TRAVIS_PYTHON_VERSION" gcc_linux-64 gxx_linux-64 cmake boost eigen numpy ipython
-- conda install --no-update-deps --yes python="$TRAVIS_PYTHON_VERSION" -c conda-forge openblas h5py
+- conda install --yes gcc_linux-64 gxx_linux-64 cmake boost eigen numpy
+- conda install --yes -c conda-forge openblas h5py
+- cd $HOME
 - pwd
+- mkdir ALM
+- cd ALM
+- git clone https://github.com/atztogo/spglib.git
+- cd spglib
+- mkdir _build && cd _build
+- cmake -DCMAKE_INSTALL_PREFIX="" ..
+- make
+- make DESTDIR=.. install
+- cd $TRAVIS_BUILD_DIR
+- pwd
+- export CPLUS_INCLUDE_PATH=$CONDA_PREFIX/include:$CONDA_PREFIX/include/eigen3:$HOME/ALM/spglib/include
+- echo $CPLUS_INCLUDE_PATH
+- echo $CC $CXX
+- export CC=$CXX
+- echo $CC
+- cd python
+- python setup.py build
+- pip install -e .
+- cd ../example
+- python sparse_Eigen.py
 
 script:
 - pwd

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@ import numpy
 try:
     from pathlib import Path
     home = str(Path.home())
-except ModuleNotFoundError:
+except ImportError:
     home = os.path.expanduser("~")
 
 # This is the switch for ALM developement. Always True for general cases.


### PR DESCRIPTION
I wrote `.travis.yml`. This PR is only for the initial setup of Travis-CI to see if ALM can be built on Travis-CI and current Travis-CI configuration does nothing about the tests yet.
 
I confirmed that ALM python module could be built on python 2.7 and 3.6 environments and `sparse_Eigen.py` could run correctly.