### PR TITLE
Modify set_supercell

### DIFF
--- a/python/_alm.c
+++ b/python/_alm.c
@@ -200,21 +200,25 @@ static PyObject * py_set_cell(PyObject *self, PyObject *args)
   int id;
   PyArrayObject* py_lavec;
   PyArrayObject* py_xcoord;
-  PyArrayObject* py_kd;
-  if (!PyArg_ParseTuple(args, "iOOO",
-                              &id,
-                              &py_lavec,
-                              &py_xcoord,
-                              &py_kd)) {
+  PyArrayObject* py_kind_in;
+  PyArrayObject* py_kind_indices;
+
+  if (!PyArg_ParseTuple(args, "iOOOO",
+                        &id,
+                        &py_lavec,
+                        &py_xcoord,
+                        &py_kind_in,
+                        &py_kind_indices)) {
     return NULL;
   }
 
   double (*lavec)[3] = (double(*)[3])PyArray_DATA(py_lavec);
   double (*xcoord)[3] = (double(*)[3])PyArray_DATA(py_xcoord);
-  const int* kd = (int*)PyArray_DATA(py_kd);
-  const int nat = PyArray_DIMS(py_kd)[0];
+  const int* kind_in = (int*)PyArray_DATA(py_kind_in);
+  const int nat = PyArray_DIMS(py_kind_in)[0];
+  int* kind_indices = (int*)PyArray_DATA(py_kind_indices);
 
-  alm_set_cell(id, nat, lavec, xcoord, kd);
+  alm_set_cell(id, nat, lavec, xcoord, kind_in, kind_indices);
 
   Py_RETURN_NONE;
 }

--- a/python/alm/alm.py
+++ b/python/alm/alm.py
@@ -16,7 +16,7 @@ class ALM:
 
     """
 
-    def __init__(self, lavec, xcoord, kind):
+    def __init__(self, lavec, xcoord, atomic_numbers):
         """
 
         Parameters
@@ -29,7 +29,7 @@ class ALM:
             Fractional coordinates of atomic points.
             shape=(num_atoms, 3)
             dtype='double'
-        kind : array_like
+        atomic_numbers : array_like
             Atomic numbers.
             shape=(num_atoms,)
             dtype='intc'
@@ -39,7 +39,8 @@ class ALM:
         self._id = None
         self._lavec = np.array(lavec, dtype='double', order='C')
         self._xcoord = np.array(xcoord, dtype='double', order='C')
-        self._kind = np.array(kind, dtype='intc', order='C')
+        self._atomic_numbers = np.array(atomic_numbers,
+                                        dtype='intc', order='C')
         self._kind_indices = None
         self._iconst = 11
         self._verbosity = 0
@@ -515,8 +516,8 @@ class ALM:
         if self._id is None:
             self._show_error_message()
 
-        self._kind_indices = np.zeros_like(self._kind)
-        alm.set_cell(self._id, self._lavec, self._xcoord, self._kind,
+        self._kind_indices = np.zeros_like(self._atomic_numbers)
+        alm.set_cell(self._id, self._lavec, self._xcoord, self._atomic_numbers,
                      self._kind_indices)
 
     def _get_ndata_used(self):

--- a/python/alm/alm.py
+++ b/python/alm/alm.py
@@ -7,10 +7,16 @@ class ALM:
 
     Attributes
     ----------
+    kind_indices : array_like
+        Atomic types represented by integer numbers starting from 1, which
+        are used internally, but currently needed to specify cutoff radii
+        in define method.
+        shape=(num_atoms,)
+        dtype='intc'
 
     """
 
-    def __init__(self, lavec, xcoord, kd):
+    def __init__(self, lavec, xcoord, kind):
         """
 
         Parameters
@@ -23,7 +29,7 @@ class ALM:
             Fractional coordinates of atomic points.
             shape=(num_atoms, 3)
             dtype='double'
-        kd : array_like
+        kind : array_like
             Atomic numbers.
             shape=(num_atoms,)
             dtype='intc'
@@ -33,10 +39,15 @@ class ALM:
         self._id = None
         self._lavec = np.array(lavec, dtype='double', order='C')
         self._xcoord = np.array(xcoord, dtype='double', order='C')
-        self._kd = np.array(kd, dtype='intc', order='C')
+        self._kind = np.array(kind, dtype='intc', order='C')
+        self._kind_indices = None
         self._iconst = 11
         self._verbosity = 0
         self._maxorder = 1
+
+    @property
+    def kind_indices(self):
+        return self._kind_indices
 
     def __enter__(self):
         self.alm_new()
@@ -52,7 +63,7 @@ class ALM:
 
         ex.::
 
-           with ALM(lavec, xcoord, kd) as alm:
+           with ALM(lavec, xcoord, kind) as alm:
 
         Note
         ----
@@ -79,7 +90,7 @@ class ALM:
 
         ex.::
 
-           with ALM(lavec, xcoord, kd) as alm:
+           with ALM(lavec, xcoord, kind) as alm:
 
         """
 
@@ -155,7 +166,7 @@ class ALM:
             np.array(u, dtype='double', order='C'),
             np.array(f, dtype='double', order='C'))
 
-    def define(self, maxorder, rcs=None, nbody=None):
+    def define(self, maxorder, cutoff_radii=None, nbody=None):
         """Define the Taylor expansion potential.
 
         Parameters
@@ -168,7 +179,7 @@ class ALM:
             - If ``maxorder = 2``, both harmonic and cubic terms are
               considered.
 
-        rcs : array_like, default = None
+        cutoff_radii : array_like, default = None
             Cutoff radii defined for each order.
             When a negative value is provided, the cutoff radius is not used.
             dtype='double'
@@ -194,26 +205,27 @@ class ALM:
                 print("The size of nbody must be equal to maxorder.")
                 raise RuntimeError
 
-        if rcs is None:
-            _rcs = None
+        if cutoff_radii is None:
+            _cutoff_radii = None
         else:
-            _rcs = np.array(rcs, dtype='double', order='C')
-            nelem = len(_rcs.ravel())
+            _cutoff_radii = np.array(cutoff_radii, dtype='double', order='C')
+            nelem = len(_cutoff_radii.ravel())
             if (nelem // maxorder) * maxorder != nelem:
-                print("The array shape of rcs is wrong.")
+                print("The array shape of cutoff_radii is wrong.")
                 raise RuntimeError
             nkd = int(round(np.sqrt(nelem // maxorder)))
             if nkd ** 2 - nelem // maxorder != 0:
-                print("The array shape of rcs is wrong.")
+                print("The array shape of cutoff_radii is wrong.")
                 raise RuntimeError
-            _rcs = np.reshape(_rcs, (maxorder, nkd, nkd), order='C')
+            _cutoff_radii = np.reshape(_cutoff_radii, (maxorder, nkd, nkd),
+                                       order='C')
 
         self._maxorder = maxorder
 
         alm.define(self._id,
                    maxorder,
                    np.array(nbody, dtype='intc'),
-                   _rcs)
+                   _cutoff_radii)
 
         alm.generate_force_constant(self._id)
 
@@ -495,14 +507,17 @@ class ALM:
         bvec = np.zeros(3 * nat * ndata_used)
         alm.get_matrix_elements(self._id, ndata_used, amat, bvec)
 
-        return np.reshape(amat, (3 * nat * ndata_used, fc_length), order='F'), bvec
+        return (np.reshape(amat, (3 * nat * ndata_used, fc_length), order='F'),
+                bvec)
 
     def _set_cell(self):
         """Private method to setup the crystal lattice information"""
         if self._id is None:
             self._show_error_message()
 
-        alm.set_cell(self._id, self._lavec, self._xcoord, self._kd)
+        self._kind_indices = np.zeros_like(self._kind)
+        alm.set_cell(self._id, self._lavec, self._xcoord, self._kind,
+                     self._kind_indices)
 
     def _get_ndata_used(self):
         """Private method to return the number of training data sets"""

--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -81,42 +81,48 @@ extern "C" {
     // void set_displacement_basis(const std::string str_disp_basis);
     // void set_periodicity(const int is_periodic[3]);
 
+    // kind_in contains integer numbers to distinguish chemical
+    // elements. This is transformed to kind in ALM format, which
+    // contains incrementing integer number starting from 1.
+    // Here the mapping from the numbers in kind_in to those in kind
+    // is made by finding unique numbers (i.e., kind_uniqe) in kind_in
+    // and keeping the order, e.g., [8, 8, 4, 4] --> [1, 1, 2, 2].
     void alm_set_cell(const int id,
                       const int nat,
                       const double lavec[3][3],
                       const double xcoord[][3],
-                      const int kd[])
+                      const int kind_in[])
     {
         int i, j, nkd;
-        int nkd_vals[nat], kd_new[nat];
-        bool kd_exist;
+        int kind_unique[nat], kind[nat];
+        bool in_kind_unique;
 
-        nkd_vals[0] = kd[0];
-        kd_new[0] = 1;
+        kind_unique[0] = kind_in[0];
+        kind[0] = 1;
         nkd = 1;
+
         for (i = 1; i < nat; ++i) {
-            kd_exist = false;
+            in_kind_unique = false;
             for (j = 0; j < nkd; ++j) {
-                if (nkd_vals[j] == kd[i]) {
-                    kd_exist = true;
-                    kd_new[i] = j + 1;
+                if (kind_unique[j] == kind_in[i]) {
+                    in_kind_unique = true;
+                    kind[i] = j + 1;
                     break;
                 }
             }
-            if (!kd_exist) {
-                nkd_vals[nkd] = kd[i];
-                kd_new[i] = nkd + 1;
+            if (!in_kind_unique) {
+                kind_unique[nkd] = kind_in[i];
+                kind[i] = nkd + 1;
                 ++nkd;
             }
         }
+
         std::string *kdname = new std::string[nkd];
-        //std::string kdname[nkd];
         for (int i = 0; i < nkd; i++) {
-            kdname[i] = atom_name[abs(nkd_vals[i]) % 118];
+            kdname[i] = atom_name[abs(kind_unique[i]) % 118];
         }
 
-
-        alm[id]->set_cell(nat, lavec, xcoord, kd_new, kdname);
+        alm[id]->set_cell(nat, lavec, xcoord, kind, kdname);
         delete [] kdname;
     }
 

--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -91,28 +91,28 @@ extern "C" {
                       const int nat,
                       const double lavec[3][3],
                       const double xcoord[][3],
-                      const int kind_in[],
+                      const int atomic_numbers[],
                       int kind[])
     {
         int i, j, nkd;
         int kind_unique[nat];
         bool in_kind_unique;
 
-        kind_unique[0] = kind_in[0];
+        kind_unique[0] = atomic_numbers[0];
         kind[0] = 1;
         nkd = 1;
 
         for (i = 1; i < nat; ++i) {
             in_kind_unique = false;
             for (j = 0; j < nkd; ++j) {
-                if (kind_unique[j] == kind_in[i]) {
+                if (kind_unique[j] == atomic_numbers[i]) {
                     in_kind_unique = true;
                     kind[i] = j + 1;
                     break;
                 }
             }
             if (!in_kind_unique) {
-                kind_unique[nkd] = kind_in[i];
+                kind_unique[nkd] = atomic_numbers[i];
                 kind[i] = nkd + 1;
                 ++nkd;
             }

--- a/python/alm_wrapper.cpp
+++ b/python/alm_wrapper.cpp
@@ -91,10 +91,11 @@ extern "C" {
                       const int nat,
                       const double lavec[3][3],
                       const double xcoord[][3],
-                      const int kind_in[])
+                      const int kind_in[],
+                      int kind[])
     {
         int i, j, nkd;
-        int kind_unique[nat], kind[nat];
+        int kind_unique[nat];
         bool in_kind_unique;
 
         kind_unique[0] = kind_in[0];

--- a/python/alm_wrapper.h
+++ b/python/alm_wrapper.h
@@ -20,7 +20,8 @@ extern "C" {
                       const int nat,
                       const double lavec[3][3],
                       const double xcoord[][3],
-                      const int kd[]);
+                      const int kd[],
+                      int kind[]);
     void alm_set_verbosity(const int id,
                            const int verbosity);
     // void set_magnetic_params(const double* const * magmom,

--- a/src/alm.cpp
+++ b/src/alm.cpp
@@ -119,29 +119,10 @@ void ALM::set_periodicity(const int is_periodic[3]) const // PERIODIC
 void ALM::set_cell(const int nat,
                    const double lavec[3][3],
                    const double xcoord[][3],
-                   const int kd[],
+                   const int kind[],
                    const std::string kdname[]) const
 {
-    std::vector<int> nkd_vals(nat);
-
-    nkd_vals[0] = kd[0];
-    auto nkd = 1;
-    for (auto i = 1; i < nat; ++i) {
-        auto kd_exist = false;
-        for (auto j = 0; j < nkd; ++j) {
-            if (nkd_vals[j] == kd[i]) {
-                kd_exist = true;
-                break;
-            }
-        }
-        if (!kd_exist) {
-            nkd_vals[nkd] = kd[i];
-            ++nkd;
-        }
-    }
-
-    // Generate the information of the supercell
-    system->set_supercell(lavec, nat, nkd, kd, xcoord);
+    system->set_supercell(lavec, nat, kind, xcoord);
     system->set_kdname(kdname);
 }
 

--- a/src/alm.h
+++ b/src/alm.h
@@ -52,7 +52,7 @@ namespace ALM_NS
         void set_cell(int nat,
                       const double lavec[3][3],
                       const double xcoord[][3],
-                      const int kd[],
+                      const int kind[],
                       const std::string kdname[]) const;
         void set_magnetic_params(const unsigned int nat,
                                  const double (*magmom)[3],

--- a/src/system.h
+++ b/src/system.h
@@ -67,7 +67,6 @@ namespace ALM_NS
 
         void set_supercell(const double [3][3],
                            const unsigned int,
-                           const unsigned int,
                            const int *,
                            const double [][3]);
         void set_kdname(const std::string *);


### PR DESCRIPTION
Because `nkd` is unnecessary to be passed to `System::set_supercell`, it was removed from the list of arguments.

I found the variable names of `kd` and `kind` were used sometimes differently and sometimes similarly, which is misleading and my fault. Now I use the following naming convention in this PR: `kd` represents a set of unique types of atoms by integers starting from 1 (size `nkd`). `kind` represents atomic types of all atoms by integers and the numbers have to be selected from `kd` (size `nat`). 

Currently in `alm_set_cell` in `alm_wrapper.cpp`, the integers in `kind_in` are assumed to be the atomic numbers. So `kind_in` is mapped to `kind` in ALM manner. However we have to think about how we can interface `cutoff_radii` in ALM python module. Inside C++ ALM, `cutoff_radii` assumes `kd`, but ALM python module doesn't explicitly provide `kd`. To circumvent this temporarily, `kind_indices` attribute was created in python ALM, that gives the atomic type indices used in ALM (i.e. `kind`). 

One more: In define method in python module, `rcs` was renamed to `cutoff_radii`.