### PR TITLE
Add python code formatter settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# See https://pre-commit.com for more informatio
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.2.0
+  hooks:
+  - id: trailing-whitespace
+    files: ^python/
+  - id: end-of-file-fixer
+    files: ^python/
+  - id: check-yaml
+    files: python/
+  - id: check-added-large-files
+    files: ^python/
+
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
+    files: ^python/
+    args:
+    - "--max-line-length=88"
+    - "--ignore=E203,W503"
+
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+  - id: black
+    files: ^pytnon/
+    args:
+    - --line-length=88
+
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 6.1.1
+  hooks:
+  - id: pydocstyle
+    files: ^python/
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+    files: ^python/
+    name: isort (python)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = "E203,W503"
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This is a PR to add python formatter and linter settings.
This is useful for the collaborative coding by mechanical checking of code writing rules, by which git-diff is expected to be minimized among developers when merging.
There are many conventions for formatting, and the setting in this PR is an example that I use for [phonopy development](https://github.com/phonopy/phonopy#development). So if @ttadano accepts having the rule, @ttadano can modify it as you like. 
If you like this, I will modify `alm.py` to pass the pre-commit hooks, i.e., currently many complaints will be raised by it.

This pre-commit is applied only to the `python/` directory. It may be useful for other files, too.