### PR TITLE
Add setup.cfg

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,7 @@
+[options]
+package_dir=
+    =.
+packages=find:
+
+[options.packages.find]
+where=.


### PR DESCRIPTION
Almost vacant `python/setup.cfg` was added to take care of modern pip (setuptools).